### PR TITLE
feat(provenance,registry): CertificateDetails struct, timestamp immutability, registry init & get_admin

### DIFF
--- a/contracts/provenance/Cargo.toml
+++ b/contracts/provenance/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc", "testutils"] }

--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -1,12 +1,20 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Bytes, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol};
 
 #[contracttype]
-pub struct ProvenanceCert {
-    pub storage_ref: Bytes,
-    pub manifest_hash: Bytes,
-    pub attestation_hash: Bytes,
-    pub creator: soroban_sdk::Address,
+pub struct CertificateDetails {
+    pub storage_id: String,
+    pub manifest_hash: String,
+    pub attestation_hash: String,
+}
+
+#[contracttype]
+pub struct Certificate {
+    pub storage_id: String,
+    pub manifest_hash: String,
+    pub attestation_hash: String,
+    pub creator: Address,
+    /// Ledger timestamp at mint time; set once and immutable (no update API).
     pub timestamp: u64,
 }
 
@@ -15,21 +23,14 @@ pub struct ProvenanceContract;
 
 #[contractimpl]
 impl ProvenanceContract {
-    /// Mint a provenance certificate after TEE attestation.
-    pub fn mint(
-        env: Env,
-        storage_ref: Bytes,
-        manifest_hash: Bytes,
-        attestation_hash: Bytes,
-        creator: soroban_sdk::Address,
-    ) -> u64 {
-        creator.require_auth();
+    pub fn mint(env: Env, to: Address, details: CertificateDetails) -> u64 {
+        to.require_auth();
         let id: u64 = env.ledger().sequence() as u64;
-        let cert = ProvenanceCert {
-            storage_ref,
-            manifest_hash,
-            attestation_hash,
-            creator,
+        let cert = Certificate {
+            storage_id: details.storage_id,
+            manifest_hash: details.manifest_hash,
+            attestation_hash: details.attestation_hash,
+            creator: to,
             timestamp: env.ledger().timestamp(),
         };
         env.storage().persistent().set(&id, &cert);
@@ -37,7 +38,43 @@ impl ProvenanceContract {
         id
     }
 
-    pub fn get(env: Env, id: u64) -> ProvenanceCert {
+    pub fn get(env: Env, id: u64) -> Certificate {
         env.storage().persistent().get(&id).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        Env, String,
+    };
+
+    #[test]
+    fn test_immutable_timestamp() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &contract_id);
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = 100;
+        });
+
+        let details = CertificateDetails {
+            storage_id: String::from_str(&env, "sid"),
+            manifest_hash: String::from_str(&env, "mhash"),
+            attestation_hash: String::from_str(&env, "ahash"),
+        };
+        let to = Address::generate(&env);
+        let id = client.mint(&to, &details);
+        let original_ts = client.get(&id).timestamp;
+
+        env.ledger().with_mut(|l| {
+            l.timestamp = 999;
+        });
+
+        assert_eq!(client.get(&id).timestamp, original_ts);
     }
 }

--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc", "testutils"] }

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -1,13 +1,31 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, BytesN, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Symbol};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Provenance,
+}
 
 #[contract]
 pub struct RegistryContract;
 
 #[contractimpl]
 impl RegistryContract {
+    pub fn init(env: Env, admin: Address, provenance: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Provenance, &provenance);
+    }
+
+    pub fn get_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Admin)
+    }
+
     /// Register an approved TEE code hash (admin-gated).
-    pub fn register_tee_hash(env: Env, admin: soroban_sdk::Address, tee_hash: BytesN<32>) {
+    pub fn register_tee_hash(env: Env, admin: Address, tee_hash: BytesN<32>) {
         admin.require_auth();
         env.storage().persistent().set(&tee_hash, &true);
         env.events().publish((Symbol::new(&env, "tee_registered"),), tee_hash);
@@ -19,7 +37,7 @@ impl RegistryContract {
     }
 
     /// Register a provider public key (admin-gated).
-    pub fn register_provider(env: Env, admin: soroban_sdk::Address, provider: BytesN<32>) {
+    pub fn register_provider(env: Env, admin: Address, provider: BytesN<32>) {
         admin.require_auth();
         env.storage().persistent().set(&provider, &true);
         env.events().publish((Symbol::new(&env, "provider_registered"),), provider);
@@ -28,5 +46,51 @@ impl RegistryContract {
     /// Check if a provider public key is registered.
     pub fn is_provider(env: Env, provider: BytesN<32>) -> bool {
         env.storage().persistent().get(&provider).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_initialize_sets_admin() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, RegistryContract);
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let provenance = Address::generate(&env);
+        client.init(&admin, &provenance);
+
+        assert_eq!(client.get_admin(), Some(admin));
+    }
+
+    #[test]
+    fn test_already_initialized_fails() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, RegistryContract);
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let provenance = Address::generate(&env);
+        client.init(&admin, &provenance);
+
+        let result = client.try_init(&admin, &provenance);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_admin_matches_init() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, RegistryContract);
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let provenance = Address::generate(&env);
+        client.init(&admin, &provenance);
+
+        assert_eq!(client.get_admin(), Some(admin));
     }
 }


### PR DESCRIPTION
## Summary

This PR resolves four issues across the \`provenance\` and \`registry\` contracts.

### #17 — [Provenance] Add \`CertificateDetails\` struct to separate input from stored data
- Replaced the single \`ProvenanceCert\` struct (raw \`Bytes\` fields) with two distinct types:
  - \`CertificateDetails { storage_id: String, manifest_hash: String, attestation_hash: String }\` — the caller-supplied mint input
  - \`Certificate { storage_id, manifest_hash, attestation_hash, creator: Address, timestamp: u64 }\` — the record persisted in storage
- Updated \`mint\` signature to \`mint(env, to: Address, details: CertificateDetails) -> u64\`; the contract constructs \`Certificate\` internally, injecting \`creator = to\` and \`timestamp = env.ledger().timestamp()\`
- Updated \`get\` return type from \`ProvenanceCert\` to \`Certificate\`

### #18 — [Provenance] Verify timestamp immutability — no update API
- Added doc comment on \`Certificate.timestamp\`: \`/// Ledger timestamp at mint time; set once and immutable (no update API).\`
- Added test \`test_immutable_timestamp\`: mints a certificate at ledger timestamp 100, advances the ledger to 999, then asserts the stored timestamp is unchanged at 100
- Added \`rlib\` crate-type and \`testutils\` dev-dependency to \`provenance/Cargo.toml\` to enable inline tests

### #19 — [Registry] Add \`init\` function with admin and provenance addresses
- Added \`DataKey\` enum (\`Admin\`, \`Provenance\`) for typed instance storage keys
- Implemented \`init(env, admin, provenance)\`: stores both addresses under \`DataKey::Admin\` / \`DataKey::Provenance\` in instance storage; panics with \`"Already initialized"\` if called a second time
- Added tests: \`test_initialize_sets_admin\` and \`test_already_initialized_fails\`

### #20 — [Registry] Add \`get_admin\` function
- Implemented \`get_admin(env) -> Option<Address>\` reading \`DataKey::Admin\` from instance storage
- Added test \`test_get_admin_matches_init\` asserting the returned address equals the one passed to \`init\`
- Added \`rlib\` crate-type and \`testutils\` dev-dependency to \`registry/Cargo.toml\` to enable inline tests

## Files changed
- \`contracts/provenance/src/lib.rs\`
- \`contracts/provenance/Cargo.toml\`
- \`contracts/registry/src/lib.rs\`
- \`contracts/registry/Cargo.toml\`

Closes #17
Closes #18
Closes #19
Closes #20