### PR TITLE
feat(provenance): implement issues #13, #14, #15, #16

### DIFF
--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -1,30 +1,35 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol};
+use soroban_sdk::{
+    contract, contractevent, contracterror, contractimpl, contracttype,
+    symbol_short, Address, Env, String,
+};
 
-#[contracttype]
-pub struct CertificateDetails {
-    pub storage_id: String,
-    pub manifest_hash: String,
-    pub attestation_hash: String,
+// #16 — typed error enum
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ProvenanceError {
+    CertificateNotFound = 1,
 }
 
-#[contracttype]
-pub struct Certificate {
-    pub storage_id: String,
-    pub manifest_hash: String,
-    pub attestation_hash: String,
-    pub creator: Address,
-    /// Ledger timestamp at mint time; set once and immutable (no update API).
-    pub timestamp: u64,
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Bytes, Env, Symbol, Address};
-
+// #14 — String fields (was Bytes)
 #[contracttype]
 pub struct ProvenanceCert {
-    pub storage_ref:      Bytes,
-    pub manifest_hash:    Bytes,
-    pub attestation_hash: Bytes,
+    pub storage_ref:      String,
+    pub manifest_hash:    String,
+    pub attestation_hash: String,
     pub creator:          Address,
     pub timestamp:        u64,
+}
+
+// #15 — typed contract event
+#[contractevent]
+pub struct CertificateMinted {
+    #[topic]
+    pub owner: Address,
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub manifest_hash: String,
 }
 
 #[contract]
@@ -32,14 +37,7 @@ pub struct ProvenanceContract;
 
 #[contractimpl]
 impl ProvenanceContract {
-    pub fn mint(env: Env, to: Address, details: CertificateDetails) -> u64 {
-        to.require_auth();
-        let id: u64 = env.ledger().sequence() as u64;
-        let cert = Certificate {
-            storage_id: details.storage_id,
-            manifest_hash: details.manifest_hash,
-            attestation_hash: details.attestation_hash,
-    /// One-time setup — stores the oracle address that is authorised to mint.
+    /// One-time setup — stores the oracle address authorised to mint.
     pub fn initialize(env: Env, oracle: Address) {
         let key = symbol_short!("ORACLE");
         if env.storage().persistent().has(&key) {
@@ -51,18 +49,28 @@ impl ProvenanceContract {
     /// Mint a provenance certificate. Only the oracle may call this.
     pub fn mint(
         env:              Env,
-        storage_ref:      Bytes,
-        manifest_hash:    Bytes,
-        attestation_hash: Bytes,
+        storage_ref:      String,
+        manifest_hash:    String,
+        attestation_hash: String,
         to:               Address,
     ) -> u64 {
-        let oracle: Address = env.storage().persistent()
+        let oracle: Address = env
+            .storage()
+            .persistent()
             .get(&symbol_short!("ORACLE"))
             .expect("Not initialized");
         oracle.require_auth();
 
+        // #13 — duplicate prevention
+        let mani_key = (symbol_short!("MANI"), manifest_hash.clone());
+        if env.storage().persistent().has(&mani_key) {
+            panic!("Certificate already exists for this manifest hash");
+        }
+
         let cnt_key = symbol_short!("CERT_CNT");
-        let id: u64 = env.storage().persistent()
+        let id: u64 = env
+            .storage()
+            .persistent()
             .get(&cnt_key)
             .unwrap_or(0u64)
             + 1;
@@ -70,115 +78,124 @@ impl ProvenanceContract {
 
         let cert = ProvenanceCert {
             storage_ref,
-            manifest_hash,
+            manifest_hash: manifest_hash.clone(),
             attestation_hash,
-            creator: to,
+            creator: to.clone(),
             timestamp: env.ledger().timestamp(),
         };
         env.storage().persistent().set(&id, &cert);
-        env.events().publish((Symbol::new(&env, "minted"),), id);
+
+        // #13 — store manifest → id mapping
+        env.storage().persistent().set(&mani_key, &id);
+
+        // #15 — emit typed event
+        CertificateMinted {
+            owner: to,
+            certificate_id: id,
+            manifest_hash,
+        }
+        .emit(&env);
+
         id
     }
 
-    pub fn get(env: Env, id: u64) -> Certificate {
-        env.storage().persistent().get(&id).unwrap()
+    // #16 — returns Result instead of panicking
+    pub fn get_certificate(
+        env: Env,
+        id:  u64,
+    ) -> Result<ProvenanceCert, ProvenanceError> {
+        env.storage()
+            .persistent()
+            .get(&id)
+            .ok_or(ProvenanceError::CertificateNotFound)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{
-        testutils::{Address as _, Ledger as _},
-        Env, String,
-    };
+    use soroban_sdk::{testutils::Address as _, Env, String};
 
-    #[test]
-    fn test_immutable_timestamp() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, ProvenanceContract);
-        let client = ProvenanceContractClient::new(&env, &contract_id);
-
-        env.ledger().with_mut(|l| {
-            l.timestamp = 100;
-        });
-
-        let details = CertificateDetails {
-            storage_id: String::from_str(&env, "sid"),
-            manifest_hash: String::from_str(&env, "mhash"),
-            attestation_hash: String::from_str(&env, "ahash"),
-        };
-        let to = Address::generate(&env);
-        let id = client.mint(&to, &details);
-        let original_ts = client.get(&id).timestamp;
-
-        env.ledger().with_mut(|l| {
-            l.timestamp = 999;
-        });
-
-        assert_eq!(client.get(&id).timestamp, original_ts);
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use soroban_sdk::{testutils::Address as _, Env, Bytes};
-
-    fn make_env() -> Env {
-        Env::default()
-    }
-
-    fn register(env: &Env) -> Address {
-        env.register_contract(None, ProvenanceContract)
-    }
-
-    fn b(env: &Env) -> Bytes {
-        Bytes::from_slice(env, b"data")
+    fn s(env: &Env, v: &str) -> String {
+        String::from_str(env, v)
     }
 
     #[test]
     fn test_double_initialization() {
-        let env    = make_env();
-        let cid    = register(&env);
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
         let client = ProvenanceContractClient::new(&env, &cid);
         let oracle = Address::generate(&env);
-
         client.initialize(&oracle);
-
-        let result = client.try_initialize(&oracle);
-        assert!(result.is_err());
+        assert!(client.try_initialize(&oracle).is_err());
     }
 
     #[test]
     fn test_mint_without_initialization() {
-        let env = make_env();
+        let env = Env::default();
         env.mock_all_auths();
-        let cid    = register(&env);
+        let cid = env.register_contract(None, ProvenanceContract);
         let client = ProvenanceContractClient::new(&env, &cid);
-        let to     = Address::generate(&env);
-        let data   = b(&env);
-
-        let result = client.try_mint(&data, &data, &data, &to);
-        assert!(result.is_err());
+        let to = Address::generate(&env);
+        assert!(client
+            .try_mint(&s(&env, "sid"), &s(&env, "mhash"), &s(&env, "ahash"), &to)
+            .is_err());
     }
 
     #[test]
     fn test_mint_multiple_certificates() {
-        let env    = make_env();
+        let env = Env::default();
         env.mock_all_auths();
-        let cid    = register(&env);
+        let cid = env.register_contract(None, ProvenanceContract);
         let client = ProvenanceContractClient::new(&env, &cid);
         let oracle = Address::generate(&env);
-        let to     = Address::generate(&env);
-        let data   = b(&env);
-
+        let to = Address::generate(&env);
         client.initialize(&oracle);
+        assert_eq!(client.mint(&s(&env, "sid"), &s(&env, "mh1"), &s(&env, "ah"), &to), 1);
+        assert_eq!(client.mint(&s(&env, "sid"), &s(&env, "mh2"), &s(&env, "ah"), &to), 2);
+        assert_eq!(client.mint(&s(&env, "sid"), &s(&env, "mh3"), &s(&env, "ah"), &to), 3);
+    }
 
-        assert_eq!(client.mint(&data, &data, &data, &to), 1);
-        assert_eq!(client.mint(&data, &data, &data, &to), 2);
-        assert_eq!(client.mint(&data, &data, &data, &to), 3);
+    // #13
+    #[test]
+    fn test_prevent_duplicate_manifest_hash() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.initialize(&oracle);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash"), &s(&env, "ahash"), &to);
+        assert!(client
+            .try_mint(&s(&env, "sid"), &s(&env, "mhash"), &s(&env, "ahash"), &to)
+            .is_err());
+    }
+
+    // #15
+    #[test]
+    fn test_certificate_minted_event() {
+        use soroban_sdk::testutils::Events as _;
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.initialize(&oracle);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash"), &s(&env, "ahash"), &to);
+        let events = env.events().all();
+        assert!(!events.is_empty());
+    }
+
+    // #16
+    #[test]
+    fn test_get_nonexistent_certificate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        assert!(client.try_get_certificate(&999u64).is_err());
     }
 }


### PR DESCRIPTION
## Summary

This PR implements four issues against `contracts/provenance` in a single clean rewrite that also fixes a corrupted file (two conflicting contract versions had been merged together).

---

### #14 — Switch `Bytes` to `soroban_sdk::String` for hash fields

- `ProvenanceCert` fields `storage_ref`, `manifest_hash`, and `attestation_hash` changed from `Bytes` to `soroban_sdk::String`.
- `mint()` signature updated accordingly.
- All tests updated to use `String::from_str(&env, "...")`.

### #13 — Prevent duplicate certificates via manifest hash index

- Before minting, checks persistent storage for key `(symbol_short!("MANI"), manifest_hash)` and panics with `"Certificate already exists for this manifest hash"` if found.
- After minting, stores the `(MANI, manifest_hash) → certificate_id` mapping.
- Added `test_prevent_duplicate_manifest_hash`.

### #15 — Add `CertificateMinted` contract event using `#[contractevent]`

- Defined `#[contractevent] struct CertificateMinted` with three `#[topic]` fields: `owner` (Address), `certificate_id` (u64), `manifest_hash` (String).
- Replaced raw `env.events().publish()` with `CertificateMinted { ... }.emit(&env)`.
- Added `test_certificate_minted_event`.

### #16 — Add `get_certificate` returning `Result<ProvenanceCert, ProvenanceError>`

- Defined `#[contracterror] enum ProvenanceError { CertificateNotFound = 1 }`.
- Renamed `get()` to `get_certificate(env, id: u64)`.
- Returns `Err(ProvenanceError::CertificateNotFound)` when the key is absent instead of panicking.
- Added `test_get_nonexistent_certificate`.

---

Closes #13
Closes #14
Closes #15
Closes #16