### PR TITLE
feat(frontend): add cn utility, Jest, ESLint, and network config

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,12 @@
+# Stellar Network RPC URLs
+NEXT_PUBLIC_TESTNET_RPC_URL=https://soroban-testnet.stellar.org
+NEXT_PUBLIC_MAINNET_RPC_URL=https://mainnet.stellar.validationcloud.io/v1/soroban/rpc
+NEXT_PUBLIC_FUTURENET_RPC_URL=https://rpc-futurenet.stellar.org
+
+# Active network (testnet | mainnet | futurenet)
+NEXT_PUBLIC_NETWORK=testnet
+
+# Soroban contract addresses
+NEXT_PUBLIC_ORACLE_CONTRACT_ID=
+NEXT_PUBLIC_PROVENANCE_CONTRACT_ID=
+NEXT_PUBLIC_REGISTRY_CONTRACT_ID=

--- a/frontend/config/network.ts
+++ b/frontend/config/network.ts
@@ -1,0 +1,38 @@
+export const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+export const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015";
+export const FUTURENET_PASSPHRASE = "Test SDF Future Network ; October 2022";
+
+export type Network = "testnet" | "mainnet" | "futurenet";
+
+export interface NetworkConfig {
+  passphrase: string;
+  rpcUrl: string;
+}
+
+export function getNetworkConfig(network: Network): NetworkConfig {
+  switch (network) {
+    case "mainnet":
+      return {
+        passphrase: MAINNET_PASSPHRASE,
+        rpcUrl: process.env.NEXT_PUBLIC_MAINNET_RPC_URL ?? "https://mainnet.stellar.validationcloud.io/v1/soroban/rpc",
+      };
+    case "futurenet":
+      return {
+        passphrase: FUTURENET_PASSPHRASE,
+        rpcUrl: process.env.NEXT_PUBLIC_FUTURENET_RPC_URL ?? "https://rpc-futurenet.stellar.org",
+      };
+    case "testnet":
+    default:
+      return {
+        passphrase: TESTNET_PASSPHRASE,
+        rpcUrl: process.env.NEXT_PUBLIC_TESTNET_RPC_URL ?? "https://soroban-testnet.stellar.org",
+      };
+  }
+}
+
+// Contract addresses (environment-variable-backed)
+export const CONTRACT_ADDRESSES = {
+  oracle: process.env.NEXT_PUBLIC_ORACLE_CONTRACT_ID ?? "",
+  provenance: process.env.NEXT_PUBLIC_PROVENANCE_CONTRACT_ID ?? "",
+  registry: process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID ?? "",
+} as const;

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals"),
+];
+
+export default eslintConfig;

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('jest').Config} */
+const config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
+};
+
+module.exports = config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,16 +6,26 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint .",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
+    "clsx": "2.1.1",
     "next": "15.0.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "tailwind-merge": "2.5.4"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "3.3.1",
+    "@types/jest": "29.5.14",
     "@types/node": "^20",
     "@types/react": "^18",
+    "eslint": "9.27.0",
+    "eslint-config-next": "15.0.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.2.6",
     "typescript": "^5",
     "tailwindcss": "^3"
   }

--- a/frontend/utils/cn.ts
+++ b/frontend/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary

## Changes

### #49 — `utils/cn.ts` class name utility
- Added `frontend/utils/cn.ts` exporting a `cn(...inputs)` function built on `clsx` + `tailwind-merge`
- Provides safe, conflict-free Tailwind class composition for all components

### #50 — Jest configuration
- Added `frontend/jest.config.js` with `ts-jest` preset, `testEnvironment: "node"`, and `@/` path alias mapping
- Added `test` and `test:watch` scripts to `frontend/package.json`

### #51 — ESLint configuration
- Added `frontend/eslint.config.mjs` extending `next/core-web-vitals` via `@eslint/eslintrc` flat-config compat
- Updated `lint` script to use `eslint .`

### #52 — Stellar network configuration
- Added `frontend/config/network.ts` exporting `TESTNET_PASSPHRASE`, `MAINNET_PASSPHRASE`, `FUTURENET_PASSPHRASE`, a `getNetworkConfig(network)` helper, and `CONTRACT_ADDRESSES` (oracle, provenance, registry) backed by environment variables
- Added `frontend/.env.local.example` documenting all required `NEXT_PUBLIC_*` variables

### Dependencies added
| Package | Type |
|---|---|
| `clsx@2.1.1` | dependency |
| `tailwind-merge@2.5.4` | dependency |
| `jest@29.7.0` | devDependency |
| `ts-jest@29.2.6` | devDependency |
| `@types/jest@29.5.14` | devDependency |
| `eslint@9.27.0` | devDependency |
| `eslint-config-next@15.0.0` | devDependency |
| `@eslint/eslintrc@3.3.1` | devDependency |

---

## Testing

- `pnpm test` — runs Jest from the frontend directory
- `pnpm lint` — runs ESLint with Next.js core-web-vitals rules

---

Closes #49, closes #50, closes #51, closes #52