### PR TITLE
feat: centralise wizard types, add Zustand store, wizard guard hook, and report-issue page

### DIFF
--- a/frontend/app/context/WizardContext.tsx
+++ b/frontend/app/context/WizardContext.tsx
@@ -1,22 +1,18 @@
 "use client";
 
 import { createContext, useContext, useState, useCallback } from "react";
-import { ContentManifest } from "@stellarveriphy/shared/types";
+import type {
+  ManifestData,
+  SPVResult,
+} from "@/src/features/verification/types/wizard.types";
 
 interface WizardContextValue {
-  manifest: Partial<ContentManifest>;
-  setManifest: (manifest: Partial<ContentManifest>) => void;
+  manifest: ManifestData;
+  setManifest: (manifest: ManifestData) => void;
   encryptionEnabled: boolean;
   setEncryptionEnabled: (enabled: boolean) => void;
-  spvResult: {
-    certificateId?: string;
-    manifestHash?: string;
-    contentHash?: string;
-    attestationHash?: string;
-    transactionHash?: string;
-    success?: boolean;
-  };
-  setSPVResult: (result: any) => void;
+  spvResult: SPVResult;
+  setSPVResult: (result: SPVResult) => void;
   reset: () => void;
 }
 
@@ -31,9 +27,9 @@ const WizardContext = createContext<WizardContextValue>({
 });
 
 export function WizardProvider({ children }: { children: React.ReactNode }) {
-  const [manifest, setManifest] = useState<Partial<ContentManifest>>({});
+  const [manifest, setManifest] = useState<ManifestData>({});
   const [encryptionEnabled, setEncryptionEnabled] = useState(false);
-  const [spvResult, setSPVResult] = useState({});
+  const [spvResult, setSPVResult] = useState<SPVResult>({});
 
   const reset = useCallback(() => {
     setManifest({});

--- a/frontend/app/report-issue/page.tsx
+++ b/frontend/app/report-issue/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+/**
+ * /report-issue
+ *
+ * A form that lets users report bugs, request features, or raise other issues.
+ * On submit it opens a pre-filled GitHub new-issue URL in a new tab so the
+ * user can review and submit the issue themselves.
+ *
+ * Validation is handled by react-hook-form.
+ */
+
+import { useForm } from "react-hook-form";
+import { useState } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type IssueType = "bug" | "feature" | "other";
+
+interface ReportIssueFormValues {
+  issueType: IssueType;
+  title: string;
+  description: string;
+  stepsToReproduce: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const GITHUB_REPO = "your-org/Stellar-Veriphy"; // ← update to your actual repo
+const GITHUB_NEW_ISSUE_URL = `https://github.com/${GITHUB_REPO}/issues/new`;
+
+const ISSUE_TYPE_LABELS: Record<IssueType, string> = {
+  bug: "🐛 Bug Report",
+  feature: "✨ Feature Request",
+  other: "💬 Other",
+};
+
+const ISSUE_TYPE_GITHUB_LABELS: Record<IssueType, string> = {
+  bug: "bug",
+  feature: "enhancement",
+  other: "question",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildGitHubUrl(values: ReportIssueFormValues): string {
+  const typeLabel = ISSUE_TYPE_LABELS[values.issueType];
+  const githubLabel = ISSUE_TYPE_GITHUB_LABELS[values.issueType];
+
+  const body = [
+    `## Description\n${values.description}`,
+    values.issueType === "bug"
+      ? `## Steps to Reproduce\n${values.stepsToReproduce}`
+      : "",
+    `---\n*Submitted via the in-app report form.*`,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const params = new URLSearchParams({
+    title: `[${typeLabel}] ${values.title}`,
+    body,
+    labels: githubLabel,
+  });
+
+  return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function ReportIssuePage() {
+  const [submitted, setSubmitted] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<ReportIssueFormValues>({
+    defaultValues: {
+      issueType: "bug",
+      title: "",
+      description: "",
+      stepsToReproduce: "",
+    },
+  });
+
+  const issueType = watch("issueType");
+
+  const onSubmit = (values: ReportIssueFormValues) => {
+    const url = buildGitHubUrl(values);
+    window.open(url, "_blank", "noopener,noreferrer");
+    setSubmitted(true);
+  };
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-gray-950 py-16 px-4">
+      <div className="max-w-2xl mx-auto">
+        {/* ── Header ── */}
+        <div className="mb-10">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+            Report an Issue
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Found a bug or have a feature idea? Fill in the form below and
+            we&apos;ll open a pre-filled GitHub issue for you to review and
+            submit.
+          </p>
+        </div>
+
+        {/* ── Success banner ── */}
+        {submitted && (
+          <div
+            role="alert"
+            className="mb-8 p-4 rounded-lg bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700"
+          >
+            <p className="text-green-800 dark:text-green-200 font-medium">
+              ✓ A GitHub issue tab has been opened. Thank you for your feedback!
+            </p>
+            <button
+              onClick={() => setSubmitted(false)}
+              className="mt-2 text-sm text-green-700 dark:text-green-300 underline hover:no-underline"
+            >
+              Submit another report
+            </button>
+          </div>
+        )}
+
+        {/* ── Form ── */}
+        {!submitted && (
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            noValidate
+            className="space-y-6"
+          >
+            {/* Issue Type */}
+            <fieldset>
+              <legend className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                Issue Type <span aria-hidden="true" className="text-red-500">*</span>
+              </legend>
+              <div className="grid grid-cols-3 gap-3">
+                {(["bug", "feature", "other"] as IssueType[]).map((type) => (
+                  <label
+                    key={type}
+                    className={`flex items-center justify-center gap-2 p-3 rounded-lg border-2 cursor-pointer text-sm font-medium transition-colors
+                      ${
+                        issueType === type
+                          ? "border-blue-600 bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-500"
+                          : "border-gray-200 text-gray-700 hover:border-gray-400 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-500"
+                      }`}
+                  >
+                    <input
+                      type="radio"
+                      value={type}
+                      className="sr-only"
+                      {...register("issueType", { required: true })}
+                    />
+                    {ISSUE_TYPE_LABELS[type]}
+                  </label>
+                ))}
+              </div>
+              {errors.issueType && (
+                <p role="alert" className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  Please select an issue type.
+                </p>
+              )}
+            </fieldset>
+
+            {/* Title */}
+            <div>
+              <label
+                htmlFor="title"
+                className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Title <span aria-hidden="true" className="text-red-500">*</span>
+              </label>
+              <input
+                id="title"
+                type="text"
+                placeholder="Short, descriptive summary of the issue"
+                aria-describedby={errors.title ? "title-error" : undefined}
+                aria-invalid={!!errors.title}
+                className={`w-full px-4 py-2.5 rounded-lg border text-gray-900 dark:text-white bg-white dark:bg-gray-900 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition
+                  ${
+                    errors.title
+                      ? "border-red-500 focus:ring-red-500"
+                      : "border-gray-300 dark:border-gray-700"
+                  }`}
+                {...register("title", {
+                  required: "Title is required.",
+                  minLength: {
+                    value: 5,
+                    message: "Title must be at least 5 characters.",
+                  },
+                  maxLength: {
+                    value: 120,
+                    message: "Title must be 120 characters or fewer.",
+                  },
+                })}
+              />
+              {errors.title && (
+                <p id="title-error" role="alert" className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  {errors.title.message}
+                </p>
+              )}
+            </div>
+
+            {/* Description */}
+            <div>
+              <label
+                htmlFor="description"
+                className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Description <span aria-hidden="true" className="text-red-500">*</span>
+              </label>
+              <textarea
+                id="description"
+                rows={5}
+                placeholder="Describe the issue or feature request in detail"
+                aria-describedby={errors.description ? "description-error" : undefined}
+                aria-invalid={!!errors.description}
+                className={`w-full px-4 py-2.5 rounded-lg border text-gray-900 dark:text-white bg-white dark:bg-gray-900 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y transition
+                  ${
+                    errors.description
+                      ? "border-red-500 focus:ring-red-500"
+                      : "border-gray-300 dark:border-gray-700"
+                  }`}
+                {...register("description", {
+                  required: "Description is required.",
+                  minLength: {
+                    value: 20,
+                    message: "Please provide at least 20 characters.",
+                  },
+                })}
+              />
+              {errors.description && (
+                <p id="description-error" role="alert" className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  {errors.description.message}
+                </p>
+              )}
+            </div>
+
+            {/* Steps to Reproduce — only shown for bug reports */}
+            {issueType === "bug" && (
+              <div>
+                <label
+                  htmlFor="stepsToReproduce"
+                  className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  Steps to Reproduce{" "}
+                  <span aria-hidden="true" className="text-red-500">*</span>
+                </label>
+                <textarea
+                  id="stepsToReproduce"
+                  rows={4}
+                  placeholder={`1. Go to ...\n2. Click on ...\n3. Observe that ...`}
+                  aria-describedby={
+                    errors.stepsToReproduce ? "steps-error" : undefined
+                  }
+                  aria-invalid={!!errors.stepsToReproduce}
+                  className={`w-full px-4 py-2.5 rounded-lg border text-gray-900 dark:text-white bg-white dark:bg-gray-900 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y font-mono text-sm transition
+                    ${
+                      errors.stepsToReproduce
+                        ? "border-red-500 focus:ring-red-500"
+                        : "border-gray-300 dark:border-gray-700"
+                    }`}
+                  {...register("stepsToReproduce", {
+                    required:
+                      issueType === "bug"
+                        ? "Steps to reproduce are required for bug reports."
+                        : false,
+                    minLength:
+                      issueType === "bug"
+                        ? {
+                            value: 10,
+                            message: "Please provide at least 10 characters.",
+                          }
+                        : undefined,
+                  })}
+                />
+                {errors.stepsToReproduce && (
+                  <p id="steps-error" role="alert" className="mt-1 text-sm text-red-600 dark:text-red-400">
+                    {errors.stepsToReproduce.message}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Submit */}
+            <div className="pt-2">
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full py-3 px-6 rounded-lg bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-950"
+              >
+                {isSubmitting ? "Opening GitHub…" : "Open GitHub Issue →"}
+              </button>
+              <p className="mt-3 text-xs text-center text-gray-500 dark:text-gray-500">
+                This will open a pre-filled GitHub issue in a new tab. You can
+                review and edit it before submitting.
+              </p>
+            </div>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/context/WizardContext.tsx
+++ b/frontend/context/WizardContext.tsx
@@ -1,22 +1,29 @@
 "use client";
 
 import { createContext, useContext, useState, ReactNode } from "react";
+import type {
+  VerificationMode,
+  FileInfo,
+  ManifestData,
+} from "@/src/features/verification/types/wizard.types";
 
-export type VerificationMode = "standard" | "advanced";
+// Re-export so existing imports of VerificationMode from this file keep working.
+export type { VerificationMode };
 
 interface WizardContextValue {
   mode: VerificationMode | null;
   setMode: (mode: VerificationMode) => void;
   file: File | null;
   setFile: (file: File | null) => void;
+  fileInfo: FileInfo | null;
   contentHash: string;
   setContentHash: (hash: string) => void;
   advancedContentHash: string;
   setAdvancedContentHash: (hash: string) => void;
   advancedManifestHash: string;
   setAdvancedManifestHash: (hash: string) => void;
-  manifest: object | null;
-  setManifest: (manifest: object | null) => void;
+  manifest: ManifestData | null;
+  setManifest: (manifest: ManifestData | null) => void;
   manifestHash: string;
   setManifestHash: (hash: string) => void;
   hashProgress: number;
@@ -31,9 +38,14 @@ export function WizardProvider({ children }: { children: ReactNode }) {
   const [contentHash, setContentHash] = useState("");
   const [advancedContentHash, setAdvancedContentHash] = useState("");
   const [advancedManifestHash, setAdvancedManifestHash] = useState("");
-  const [manifest, setManifest] = useState<object | null>(null);
+  const [manifest, setManifest] = useState<ManifestData | null>(null);
   const [manifestHash, setManifestHash] = useState("");
   const [hashProgress, setHashProgress] = useState(0);
+
+  // Derive a serialisable FileInfo from the raw File object.
+  const fileInfo: FileInfo | null = file
+    ? { name: file.name, size: file.size, type: file.type }
+    : null;
 
   return (
     <WizardContext.Provider
@@ -42,6 +54,7 @@ export function WizardProvider({ children }: { children: ReactNode }) {
         setMode,
         file,
         setFile,
+        fileInfo,
         contentHash,
         setContentHash,
         advancedContentHash,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,10 @@
     "prismjs": "^1.30.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.54.2",
     "react-icons": "^5.6.0",
-    "tailwind-merge": "2.5.4"
+    "tailwind-merge": "2.5.4",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.1",

--- a/frontend/src/features/verification/hooks/useWizardGuard.ts
+++ b/frontend/src/features/verification/hooks/useWizardGuard.ts
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * useWizardGuard
+ *
+ * Redirects the user back to /verify (the first wizard step) if they try to
+ * access a later step without having completed the required previous steps.
+ *
+ * Usage:
+ *   // Inside a step-2 page component:
+ *   useWizardGuard(2); // requires steps 0 and 1 to be complete
+ *
+ * The guard runs on mount and whenever `currentStep` or `completedSteps`
+ * change, so it also handles the case where the user navigates back and
+ * clears a step.
+ */
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useWizardStore } from "../store/wizard.store";
+
+/**
+ * @param minimumStep - The step index the current page represents.
+ *   All steps with index < minimumStep must be marked complete before the
+ *   user is allowed to view this page.
+ * @param redirectTo - Optional override for the redirect destination.
+ *   Defaults to "/verify".
+ */
+export function useWizardGuard(
+  minimumStep: number,
+  redirectTo = "/verify"
+): void {
+  const router = useRouter();
+  const completedSteps = useWizardStore((s) => s.completedSteps);
+
+  useEffect(() => {
+    // Check that every step before minimumStep has been completed.
+    const prerequisitesMet = Array.from(
+      { length: minimumStep },
+      (_, i) => i
+    ).every((i) => completedSteps[i]);
+
+    if (!prerequisitesMet) {
+      router.replace(redirectTo);
+    }
+  }, [completedSteps, minimumStep, redirectTo, router]);
+}

--- a/frontend/src/features/verification/store/wizard.store.ts
+++ b/frontend/src/features/verification/store/wizard.store.ts
@@ -1,0 +1,135 @@
+/**
+ * Zustand store for wizard state.
+ *
+ * Mirrors the shape of WizardState and persists to sessionStorage so that
+ * state survives page navigations within the same browser tab but is cleared
+ * when the tab is closed.
+ *
+ * Use this store as a complement to (or replacement for) WizardContext when
+ * you need state that outlives a single React subtree.
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type {
+  FileInfo,
+  ManifestData,
+  SPVResult,
+  VerificationMode,
+  WizardState,
+} from "../types/wizard.types";
+
+// ─── Action signatures ────────────────────────────────────────────────────────
+
+interface WizardActions {
+  /** Move to a specific step by index. */
+  setStep: (step: number) => void;
+  /** Mark a step as complete or incomplete. */
+  setStepComplete: (step: number, complete: boolean) => void;
+  /** Set the verification mode. */
+  setMode: (mode: VerificationMode) => void;
+  /**
+   * Store serialisable file metadata.
+   * The raw `File` object cannot be persisted; pass `null` to clear.
+   */
+  setFile: (fileInfo: FileInfo | null) => void;
+  /** Store the SHA-256 content hash computed from the uploaded file. */
+  setContentHash: (hash: string) => void;
+  /** Update the hashing progress (0–100). */
+  setHashProgress: (progress: number) => void;
+  /** Store the manually entered content hash (advanced mode). */
+  setAdvancedContentHash: (hash: string) => void;
+  /** Store the manually entered manifest hash (advanced mode). */
+  setAdvancedManifestHash: (hash: string) => void;
+  /** Store the parsed manifest object. */
+  setManifest: (manifest: ManifestData | null) => void;
+  /** Store the SHA-256 hash of the manifest file. */
+  setManifestHash: (hash: string) => void;
+  /** Toggle encryption for the SPV submission. */
+  setEncryptionEnabled: (enabled: boolean) => void;
+  /** Store the result returned after SPV submission. */
+  setSPVResult: (result: SPVResult) => void;
+  /** Reset the entire wizard back to its initial state. */
+  reset: () => void;
+}
+
+// ─── Initial state ────────────────────────────────────────────────────────────
+
+const TOTAL_STEPS = 5;
+
+const initialState: WizardState = {
+  currentStep: 0,
+  completedSteps: Array(TOTAL_STEPS).fill(false) as boolean[],
+  mode: null,
+  fileInfo: null,
+  contentHash: "",
+  hashProgress: 0,
+  advancedContentHash: "",
+  advancedManifestHash: "",
+  manifest: null,
+  manifestHash: "",
+  encryptionEnabled: false,
+  spvResult: {},
+};
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+export const useWizardStore = create<WizardState & WizardActions>()(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      setStep: (step) => set({ currentStep: step }),
+
+      setStepComplete: (step, complete) =>
+        set((state) => {
+          const completedSteps = [...state.completedSteps];
+          completedSteps[step] = complete;
+          return { completedSteps };
+        }),
+
+      setMode: (mode) => set({ mode }),
+
+      setFile: (fileInfo) => set({ fileInfo }),
+
+      setContentHash: (contentHash) => set({ contentHash }),
+
+      setHashProgress: (hashProgress) => set({ hashProgress }),
+
+      setAdvancedContentHash: (advancedContentHash) =>
+        set({ advancedContentHash }),
+
+      setAdvancedManifestHash: (advancedManifestHash) =>
+        set({ advancedManifestHash }),
+
+      setManifest: (manifest) => set({ manifest }),
+
+      setManifestHash: (manifestHash) => set({ manifestHash }),
+
+      setEncryptionEnabled: (encryptionEnabled) => set({ encryptionEnabled }),
+
+      setSPVResult: (spvResult) => set({ spvResult }),
+
+      reset: () => set(initialState),
+    }),
+    {
+      name: "stellar-veriphy-wizard",
+      storage: createJSONStorage(() => sessionStorage),
+      // Only persist the data fields; transient UI state like hashProgress
+      // does not need to survive a navigation.
+      partialize: (state) => ({
+        currentStep: state.currentStep,
+        completedSteps: state.completedSteps,
+        mode: state.mode,
+        fileInfo: state.fileInfo,
+        contentHash: state.contentHash,
+        advancedContentHash: state.advancedContentHash,
+        advancedManifestHash: state.advancedManifestHash,
+        manifest: state.manifest,
+        manifestHash: state.manifestHash,
+        encryptionEnabled: state.encryptionEnabled,
+        spvResult: state.spvResult,
+      }),
+    }
+  )
+);

--- a/frontend/src/features/verification/types/wizard.types.ts
+++ b/frontend/src/features/verification/types/wizard.types.ts
@@ -1,0 +1,102 @@
+/**
+ * Centralised wizard types shared between WizardContext and the Zustand store.
+ * Import from here instead of duplicating definitions across files.
+ */
+
+// ─── Primitives ──────────────────────────────────────────────────────────────
+
+/** Which verification path the user has chosen. */
+export type VerificationMode = "standard" | "advanced";
+
+// ─── Domain objects ──────────────────────────────────────────────────────────
+
+/** Lightweight descriptor for the file the user has selected. */
+export interface FileInfo {
+  /** Original filename as reported by the browser. */
+  name: string;
+  /** File size in bytes. */
+  size: number;
+  /** MIME type string (e.g. "video/mp4"). */
+  type: string;
+}
+
+/** Parsed manifest payload attached to the content. */
+export interface ManifestData {
+  /** SHA-256 hex digest of the media file. */
+  contentHash?: string;
+  /** Stellar public key of the content creator. */
+  creator?: string;
+  /** ISO 8601 creation timestamp. */
+  timestamp?: string;
+  /** Optional device / location / AI-model metadata. */
+  metadata?: {
+    device?: string;
+    location?: string;
+    aiModel?: string;
+  };
+  /** Catch-all for any additional manifest fields. */
+  [key: string]: unknown;
+}
+
+/** Result returned after a Stellar Provenance Verification (SPV) submission. */
+export interface SPVResult {
+  /** On-chain certificate identifier. */
+  certificateId?: string;
+  /** SHA-256 hex digest of the manifest. */
+  manifestHash?: string;
+  /** SHA-256 hex digest of the media content. */
+  contentHash?: string;
+  /** Hash of the TEE attestation. */
+  attestationHash?: string;
+  /** Stellar transaction hash. */
+  transactionHash?: string;
+  /** Whether the verification succeeded. */
+  success?: boolean;
+}
+
+// ─── Wizard state ─────────────────────────────────────────────────────────────
+
+/**
+ * Complete shape of the wizard state used by both the React context and the
+ * Zustand store.  Keep the two in sync by importing this interface.
+ */
+export interface WizardState {
+  // ── Step tracking ──────────────────────────────────────────────────────────
+  /** Zero-based index of the currently active step. */
+  currentStep: number;
+  /** Bitmask / array tracking which steps have been completed. */
+  completedSteps: boolean[];
+
+  // ── Mode ───────────────────────────────────────────────────────────────────
+  /** Verification mode chosen by the user. */
+  mode: VerificationMode | null;
+
+  // ── Standard-mode file data ────────────────────────────────────────────────
+  /**
+   * Serialisable file descriptor (the raw `File` object cannot be persisted to
+   * sessionStorage, so we store metadata separately).
+   */
+  fileInfo: FileInfo | null;
+  /** SHA-256 hex digest computed from the uploaded file. */
+  contentHash: string;
+  /** Progress percentage (0–100) while the hash is being computed. */
+  hashProgress: number;
+
+  // ── Advanced-mode manual inputs ────────────────────────────────────────────
+  /** Manually entered content hash (advanced mode). */
+  advancedContentHash: string;
+  /** Manually entered manifest hash (advanced mode). */
+  advancedManifestHash: string;
+
+  // ── Manifest ───────────────────────────────────────────────────────────────
+  /** Parsed manifest object. */
+  manifest: ManifestData | null;
+  /** SHA-256 hex digest of the manifest file. */
+  manifestHash: string;
+
+  // ── SPV options & results ──────────────────────────────────────────────────
+  /** Whether the user has opted in to encrypting the submission. */
+  encryptionEnabled: boolean;
+  /** Result of the SPV submission. */
+  spvResult: SPVResult;
+}


### PR DESCRIPTION

closes #104 
closes #103 
closes #102 
closes #101 

feat: centralise wizard types, add Zustand store, wizard guard hook, and report-issue page

- Add wizard.types.ts with FileInfo, ManifestData, SPVResult, WizardState, VerificationMode
- Add wizard.store.ts (Zustand + sessionStorage persist) with setFile, setContentHash, setManifest, reset actions
- Add useWizardGuard hook that redirects to /verify if step prerequisites are unmet
- Add /report-issue page with react-hook-form validation and GitHub issue URL generation
- Update both WizardContext files to import shared types instead of duplicating them
- Add zustand and react-hook-form to package.json dependencies
