### PR TITLE
feat: Add Content Security Policy and security headers to Next.js config

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,51 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: `default-src 'self'; 
+              script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; 
+              style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com; 
+              img-src 'self' data: https: blob:; 
+              font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com; 
+              connect-src 'self' https://horizon.stellar.org https://horizon-testnet.stellar.org https://soroban-rpc.mainnet.stellar.org https://soroban-rpc.testnet.stellar.org https://gateway.ipfs.io https://dweb.link https://*.ipfs.io wss:; 
+              frame-ancestors 'none'; 
+              base-uri 'self'; 
+              form-action 'self'`.replace(/\s+/g, " "),
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), payment=()",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains",
+          },
+          {
+            key: "X-DNS-Prefetch-Control",
+            value: "on",
+          },
+        ],
+      },
+    ];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
- Add CSP headers with allowlist for Stellar RPC endpoints and IPFS gateways
- Add X-Frame-Options: DENY to prevent clickjacking
- Add X-Content-Type-Options: nosniff to prevent MIME type sniffing
- Add Referrer-Policy: strict-origin-when-cross-origin for privacy
- Add Permissions-Policy to restrict browser features
- Add HSTS header for HTTPS enforcement
- Apply headers to all routes and assets

Closes #127