### PR TITLE
Certificate collections, TEE hash versioning, provider reputation, and certificate lock

### DIFF
--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -13,6 +13,7 @@ pub enum ProvenanceError {
     DuplicateCertificate = 3,
     BatchSizeExceeded = 4,
     CollectionNotFound = 5,
+    CertificateLocked = 6,
 }
 
 // #14 — String fields (was Bytes)
@@ -26,6 +27,7 @@ pub struct ProvenanceCert {
     pub revoked:          bool,
     pub revocation_reason: Option<RevocationReason>,
     pub revocation_timestamp: Option<u64>,
+    pub locked:           bool,
 }
 
 // #173 — Certificate metadata with version tracking
@@ -43,6 +45,15 @@ pub struct MetadataVersion {
     pub display_name: String,
     pub description: String,
     pub updated_at: u64,
+}
+
+// #184 — Certificate immutability lock event
+#[contractevent]
+pub struct CertificateLockedEvent {
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub locked_by: Address,
 }
 
 // #185 — Certificate collection/portfolio
@@ -162,6 +173,7 @@ impl ProvenanceContract {
             revoked: false,
             revocation_reason: None,
             revocation_timestamp: None,
+            locked: false,
         };
         env.storage().persistent().set(&id, &cert);
 
@@ -202,6 +214,11 @@ impl ProvenanceContract {
             .ok_or(ProvenanceError::CertificateNotFound)?;
 
         cert.creator.require_auth();
+
+        if cert.locked {
+            return Err(ProvenanceError::CertificateLocked);
+        }
+
         let old_owner = cert.creator.clone();
 
         cert.creator = new_owner.clone();
@@ -237,6 +254,10 @@ impl ProvenanceContract {
             .ok_or(ProvenanceError::CertificateNotFound)?;
 
         cert.creator.require_auth();
+
+        if cert.locked {
+            return Err(ProvenanceError::CertificateLocked);
+        }
 
         let metadata_key = (symbol_short!("META"), certificate_id);
         let mut metadata: CertificateMetadata = env.storage()
@@ -483,6 +504,30 @@ impl ProvenanceContract {
             .persistent()
             .get(&(symbol_short!("CERTCOLL"), certificate_id))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// #184 — Irreversibly lock a certificate, preventing any further
+    /// modifications (transfers, metadata updates) even by its owner.
+    pub fn lock_certificate(env: Env, certificate_id: u64) -> Result<(), ProvenanceError> {
+        let mut cert = env.storage()
+            .persistent()
+            .get::<u64, ProvenanceCert>(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        cert.creator.require_auth();
+
+        if !cert.locked {
+            cert.locked = true;
+            env.storage().persistent().set(&certificate_id, &cert);
+
+            CertificateLockedEvent {
+                certificate_id,
+                locked_by: cert.creator,
+            }
+            .emit(&env);
+        }
+
+        Ok(())
     }
 }
 

--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -12,6 +12,7 @@ pub enum ProvenanceError {
     Unauthorized = 2,
     DuplicateCertificate = 3,
     BatchSizeExceeded = 4,
+    CollectionNotFound = 5,
 }
 
 // #14 — String fields (was Bytes)
@@ -42,6 +43,15 @@ pub struct MetadataVersion {
     pub display_name: String,
     pub description: String,
     pub updated_at: u64,
+}
+
+// #185 — Certificate collection/portfolio
+#[contracttype]
+pub struct Collection {
+    pub owner: Address,
+    pub name: String,
+    pub description: String,
+    pub created_at: u64,
 }
 
 // #15 — typed contract event
@@ -377,6 +387,102 @@ impl ProvenanceContract {
         .emit(&env);
 
         Ok(certificate_ids)
+    }
+
+    /// #185 — Create a new certificate collection/portfolio.
+    pub fn create_collection(
+        env: Env,
+        owner: Address,
+        name: String,
+        description: String,
+    ) -> u64 {
+        owner.require_auth();
+
+        let cnt_key = symbol_short!("COLL_CNT");
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&cnt_key)
+            .unwrap_or(0u64)
+            + 1;
+        env.storage().persistent().set(&cnt_key, &id);
+
+        let collection = Collection {
+            owner,
+            name,
+            description,
+            created_at: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&(symbol_short!("COLL"), id), &collection);
+
+        id
+    }
+
+    /// #185 — Fetch a collection by id.
+    pub fn get_collection(env: Env, collection_id: u64) -> Result<Collection, ProvenanceError> {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("COLL"), collection_id))
+            .ok_or(ProvenanceError::CollectionNotFound)
+    }
+
+    /// #185 — Add a certificate to a collection. A certificate may belong to
+    /// multiple collections simultaneously.
+    pub fn add_certificate_to_collection(
+        env: Env,
+        collection_id: u64,
+        certificate_id: u64,
+    ) -> Result<(), ProvenanceError> {
+        let collection: Collection = env
+            .storage()
+            .persistent()
+            .get(&(symbol_short!("COLL"), collection_id))
+            .ok_or(ProvenanceError::CollectionNotFound)?;
+        collection.owner.require_auth();
+
+        if !env.storage().persistent().has(&certificate_id) {
+            return Err(ProvenanceError::CertificateNotFound);
+        }
+
+        let coll_certs_key = (symbol_short!("COLLCERT"), collection_id);
+        let mut coll_certs: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&coll_certs_key)
+            .unwrap_or(Vec::new(&env));
+        if !coll_certs.contains(&certificate_id) {
+            coll_certs.push_back(certificate_id);
+            env.storage().persistent().set(&coll_certs_key, &coll_certs);
+        }
+
+        let cert_colls_key = (symbol_short!("CERTCOLL"), certificate_id);
+        let mut cert_colls: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&cert_colls_key)
+            .unwrap_or(Vec::new(&env));
+        if !cert_colls.contains(&collection_id) {
+            cert_colls.push_back(collection_id);
+            env.storage().persistent().set(&cert_colls_key, &cert_colls);
+        }
+
+        Ok(())
+    }
+
+    /// #185 — Query all certificate ids belonging to a collection.
+    pub fn get_certificates_in_collection(env: Env, collection_id: u64) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("COLLCERT"), collection_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// #185 — Query all collection ids a certificate belongs to.
+    pub fn get_collections_for_certificate(env: Env, certificate_id: u64) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("CERTCOLL"), certificate_id))
+            .unwrap_or(Vec::new(&env))
     }
 }
 

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -87,6 +87,7 @@ pub enum Error {
     ProposalNotFound = 4,
     ProposalExpired = 5,
     InsufficientApprovals = 6,
+    TeeHashNotFound = 7,
 }
 
 // ---------------------------------------------------------------------------
@@ -104,6 +105,9 @@ pub enum DataKey {
     Proposal(u64),
     ProposalApprovals(u64),
     NextProposalId,
+    TeeHashVersionInfo(BytesN<32>), // #187
+    TeeHashesByVersion(u32),        // #187
+    TeeHashVersionHistory,          // #187
 }
 
 // ---------------------------------------------------------------------------
@@ -128,6 +132,20 @@ pub struct Proposal {
     pub created_ledger: u32,
     pub execution_ledger: u32,
     pub executed: bool,
+}
+
+// ---------------------------------------------------------------------------
+// #187 – TEE hash versioning
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TeeHashVersionInfo {
+    pub code_hash: BytesN<32>,
+    pub version: u32,
+    pub added_at: u64,
+    pub deprecated: bool,
+    pub deprecated_at: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +220,119 @@ impl RegistryContract {
             .persistent()
             .get(&DataKey::TeeHash(code_hash))
             .unwrap_or(false)
+    }
+
+    // -----------------------------------------------------------------------
+    // #187 – TEE hash versioning
+    // -----------------------------------------------------------------------
+
+    /// Register an approved TEE code hash with an explicit version (admin-gated).
+    /// Multiple versions may be active simultaneously, and multiple hashes may
+    /// share the same version.
+    pub fn add_tee_hash_version(env: Env, code_hash: BytesN<32>, version: u32) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TeeHash(code_hash.clone()), &true);
+
+        let info = TeeHashVersionInfo {
+            code_hash: code_hash.clone(),
+            version,
+            added_at: env.ledger().timestamp(),
+            deprecated: false,
+            deprecated_at: None,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::TeeHashVersionInfo(code_hash.clone()), &info);
+
+        let version_key = DataKey::TeeHashesByVersion(version);
+        let mut hashes: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&version_key)
+            .unwrap_or(Vec::new(&env));
+        if !hashes.contains(&code_hash) {
+            hashes.push_back(code_hash);
+            env.storage().persistent().set(&version_key, &hashes);
+        }
+
+        let mut history: Vec<TeeHashVersionInfo> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TeeHashVersionHistory)
+            .unwrap_or(Vec::new(&env));
+        history.push_back(info);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TeeHashVersionHistory, &history);
+    }
+
+    /// Deprecate a previously registered TEE code hash (admin-gated). The
+    /// hash remains queryable but is flagged as deprecated; other active
+    /// versions are unaffected.
+    pub fn deprecate_tee_hash(env: Env, code_hash: BytesN<32>) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        let mut info: TeeHashVersionInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TeeHashVersionInfo(code_hash.clone()))
+            .ok_or(Error::TeeHashNotFound)?;
+
+        info.deprecated = true;
+        info.deprecated_at = Some(env.ledger().timestamp());
+        env.storage()
+            .persistent()
+            .set(&DataKey::TeeHashVersionInfo(code_hash), &info);
+
+        let mut history: Vec<TeeHashVersionInfo> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TeeHashVersionHistory)
+            .unwrap_or(Vec::new(&env));
+        history.push_back(info);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TeeHashVersionHistory, &history);
+
+        Ok(())
+    }
+
+    /// Fetch version metadata for a TEE code hash.
+    pub fn get_tee_hash_version(env: Env, code_hash: BytesN<32>) -> Result<TeeHashVersionInfo, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TeeHashVersionInfo(code_hash))
+            .ok_or(Error::TeeHashNotFound)
+    }
+
+    /// Query all TEE code hashes registered under a given version.
+    pub fn get_tee_hashes_by_version(env: Env, version: u32) -> Vec<BytesN<32>> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TeeHashesByVersion(version))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Full chronological history of TEE hash version registrations and
+    /// deprecations.
+    pub fn get_tee_hash_version_history(env: Env) -> Vec<TeeHashVersionInfo> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TeeHashVersionHistory)
+            .unwrap_or(Vec::new(&env))
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -88,6 +88,7 @@ pub enum Error {
     ProposalExpired = 5,
     InsufficientApprovals = 6,
     TeeHashNotFound = 7,
+    ProviderNotFound = 8,
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +109,8 @@ pub enum DataKey {
     TeeHashVersionInfo(BytesN<32>), // #187
     TeeHashesByVersion(u32),        // #187
     TeeHashVersionHistory,          // #187
+    ProviderReputation(BytesN<32>), // #186
+    ProviderList,                   // #186
 }
 
 // ---------------------------------------------------------------------------
@@ -147,6 +150,24 @@ pub struct TeeHashVersionInfo {
     pub deprecated: bool,
     pub deprecated_at: Option<u64>,
 }
+
+// ---------------------------------------------------------------------------
+// #186 – Provider reputation system
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProviderReputation {
+    pub score: u32,
+    pub total_verifications: u64,
+    pub successful_count: u64,
+    pub failed_count: u64,
+    pub last_updated: u64,
+}
+
+const REPUTATION_MAX_SCORE: u32 = 1000;
+const REPUTATION_DECAY_PERIOD_SECS: u64 = 2_592_000; // 30 days
+const REPUTATION_DECAY_AMOUNT: u32 = 50;
 
 // ---------------------------------------------------------------------------
 // #24 – VerificationResult
@@ -349,7 +370,35 @@ impl RegistryContract {
         admin.require_auth();
         env.storage()
             .persistent()
-            .set(&DataKey::Provider(provider), &true);
+            .set(&DataKey::Provider(provider.clone()), &true);
+
+        // #186 — seed reputation tracking for newly registered providers
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::ProviderReputation(provider.clone()))
+        {
+            let reputation = ProviderReputation {
+                score: REPUTATION_MAX_SCORE / 2,
+                total_verifications: 0,
+                successful_count: 0,
+                failed_count: 0,
+                last_updated: env.ledger().timestamp(),
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::ProviderReputation(provider.clone()), &reputation);
+
+            let mut providers: Vec<BytesN<32>> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::ProviderList)
+                .unwrap_or(Vec::new(&env));
+            providers.push_back(provider);
+            env.storage()
+                .persistent()
+                .set(&DataKey::ProviderList, &providers);
+        }
     }
 
     /// Check whether a provider public key is registered.  #21
@@ -358,6 +407,109 @@ impl RegistryContract {
             .persistent()
             .get(&DataKey::Provider(provider))
             .unwrap_or(false)
+    }
+
+    // -----------------------------------------------------------------------
+    // #186 – provider reputation system
+    // -----------------------------------------------------------------------
+
+    /// Record the outcome of a provider verification and recompute its
+    /// reputation score (admin-gated).
+    pub fn record_verification_result(
+        env: Env,
+        provider: BytesN<32>,
+        success: bool,
+    ) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        let mut reputation: ProviderReputation = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProviderReputation(provider.clone()))
+            .ok_or(Error::ProviderNotFound)?;
+
+        reputation.total_verifications += 1;
+        if success {
+            reputation.successful_count += 1;
+        } else {
+            reputation.failed_count += 1;
+        }
+
+        reputation.score = ((reputation.successful_count as u128 * REPUTATION_MAX_SCORE as u128)
+            / reputation.total_verifications as u128) as u32;
+        reputation.last_updated = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProviderReputation(provider), &reputation);
+
+        Ok(())
+    }
+
+    /// Apply time-based decay to a provider's score if it has been inactive
+    /// for one or more decay periods. Callable by anyone; decay is a
+    /// deterministic function of elapsed time, not an admin action.
+    pub fn apply_reputation_decay(env: Env, provider: BytesN<32>) -> Result<(), Error> {
+        let mut reputation: ProviderReputation = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProviderReputation(provider.clone()))
+            .ok_or(Error::ProviderNotFound)?;
+
+        let now = env.ledger().timestamp();
+        let elapsed = now.saturating_sub(reputation.last_updated);
+        let periods = elapsed / REPUTATION_DECAY_PERIOD_SECS;
+
+        if periods > 0 {
+            let decay = REPUTATION_DECAY_AMOUNT.saturating_mul(periods as u32);
+            reputation.score = reputation.score.saturating_sub(decay);
+            reputation.last_updated = now;
+            env.storage()
+                .persistent()
+                .set(&DataKey::ProviderReputation(provider), &reputation);
+        }
+
+        Ok(())
+    }
+
+    /// Fetch a provider's current reputation.
+    pub fn get_provider_reputation(env: Env, provider: BytesN<32>) -> Result<ProviderReputation, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ProviderReputation(provider))
+            .ok_or(Error::ProviderNotFound)
+    }
+
+    /// Query all registered providers whose score meets or exceeds a
+    /// threshold.
+    pub fn get_providers_by_reputation_threshold(
+        env: Env,
+        min_score: u32,
+    ) -> Vec<BytesN<32>> {
+        let providers: Vec<BytesN<32>> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProviderList)
+            .unwrap_or(Vec::new(&env));
+
+        let mut result: Vec<BytesN<32>> = Vec::new(&env);
+        for provider in providers.iter() {
+            if let Some(reputation) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, ProviderReputation>(&DataKey::ProviderReputation(provider.clone()))
+            {
+                if reputation.score >= min_score {
+                    result.push_back(provider);
+                }
+            }
+        }
+        result
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR bundles four independent contract feature additions:

### #185 — Certificate Collection/Portfolio Support (provenance)
- Added `Collection` struct (`owner`, `name`, `description`, `created_at`)
- `create_collection(owner, name, description) -> u64` — owner-authenticated
- `add_certificate_to_collection(collection_id, certificate_id)` — collection-owner-authenticated, validates the certificate exists
- `get_certificates_in_collection(collection_id) -> Vec<u64>`
- `get_collections_for_certificate(certificate_id) -> Vec<u64>` — a certificate can belong to multiple collections simultaneously
- `get_collection(collection_id) -> Result<Collection, ProvenanceError>`
- New `ProvenanceError::CollectionNotFound`

### #187 — TEE Hash Versioning (registry)
- Added `TeeHashVersionInfo` struct (`code_hash`, `version`, `added_at`, `deprecated`, `deprecated_at`)
- `add_tee_hash_version(code_hash, version)` — admin-gated, supports multiple hashes per version and multiple active versions simultaneously
- `deprecate_tee_hash(code_hash)` — admin-gated deprecation flag (non-destructive; other versions unaffected)
- `get_tee_hash_version(code_hash) -> Result<TeeHashVersionInfo, Error>`
- `get_tee_hashes_by_version(version) -> Vec<BytesN<32>>`
- `get_tee_hash_version_history() -> Vec<TeeHashVersionInfo>` — chronological log of registrations/deprecations
- New `Error::TeeHashNotFound`
- Existing `add_tee_hash` / `is_tee_hash_approved` are untouched for backward compatibility

### #186 — Provider Reputation System (registry)
- Added `ProviderReputation` struct exactly as specified in the issue (`score: u32` 0–1000, `total_verifications`, `successful_count`, `failed_count`, `last_updated`)
- `add_provider` now seeds a reputation record (score 500) and tracks providers in a queryable list
- `record_verification_result(provider, success)` — admin-gated, updates counts and recalculates `score = successful_count * 1000 / total_verifications`
- `apply_reputation_decay(provider)` — reduces score for providers inactive beyond a 30-day period (50 points per elapsed period), callable by anyone since it's a deterministic function of elapsed time
- `get_provider_reputation(provider) -> Result<ProviderReputation, Error>`
- `get_providers_by_reputation_threshold(min_score) -> Vec<BytesN<32>>`
- New `Error::ProviderNotFound`

### #184 — Certificate Immutability Lock (provenance)
- Added `locked: bool` field to `ProvenanceCert`
- `lock_certificate(certificate_id)` — owner-authenticated, irreversible (no-op if already locked), emits `CertificateLockedEvent`
- `transfer_certificate` and `update_metadata` now reject any modification with `ProvenanceError::CertificateLocked` once a certificate is locked
- New `ProvenanceError::CertificateLocked`

Closes #185
Closes #187
Closes #186
Closes #184

## Notes
- Per instructions, no new tests were written for this PR; existing tests are untouched.
- No Rust toolchain (rustc/cargo/rustfmt) or frontend deps were available in the dev sandbox this was authored in, so builds/hooks could not be run locally — CI should be treated as the first real compile/lint pass.
- Unrelated pre-existing issues noticed but intentionally left out of scope: `RevocationReason` is referenced in `ProvenanceCert` (provenance/src/lib.rs) but never defined; `mint_batch` constructs a `ProvenanceCert` missing several required struct fields; `#[contracterror]` is used in registry/src/lib.rs without being imported.

## Test plan
- [ ] `cargo test -p provenance`
- [ ] `cargo test -p registry`
- [ ] Manual review of auth-gating on new mutating functions (`lock_certificate`, `add_certificate_to_collection`, `record_verification_result`, `deprecate_tee_hash`, `add_tee_hash_version`)