### PR TITLE
feat(provenance): expiration dates, verification levels, linking, and stats (#176-#179)

### DIFF
--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -13,6 +13,7 @@ pub enum ProvenanceError {
     DuplicateCertificate = 3,
     BatchSizeExceeded = 4,
     UnauthorizedRevocation = 5,
+    InvalidExpiration = 6,
 }
 
 // #171 — Revocation reason
@@ -36,6 +37,8 @@ pub struct ProvenanceCert {
     pub revoked:          bool,
     pub revocation_reason: Option<RevocationReason>,
     pub revocation_timestamp: Option<u64>,
+    // #177 — optional expiration
+    pub expires_at:       Option<u64>,
 }
 
 // #173 — Certificate metadata with version tracking
@@ -106,6 +109,26 @@ pub struct CertificateRevoked {
     pub reason: String,
 }
 
+// #177 — Expiration renewed event
+#[contractevent]
+pub struct CertificateRenewed {
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub renewed_by: Address,
+    pub new_expires_at: u64,
+}
+
+// #177 — Expiration warning event
+#[contractevent]
+pub struct CertificateExpirationWarning {
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub owner: Address,
+    pub expires_at: u64,
+}
+
 #[contract]
 pub struct ProvenanceContract;
 
@@ -173,6 +196,7 @@ impl ProvenanceContract {
             revoked: false,
             revocation_reason: None,
             revocation_timestamp: None,
+            expires_at: None,
         };
         env.storage().persistent().set(&id, &cert);
 
@@ -251,6 +275,106 @@ impl ProvenanceContract {
             .get(&certificate_id)
             .map(|cert: ProvenanceCert| cert.revoked)
             .ok_or(ProvenanceError::CertificateNotFound)
+    }
+
+    /// #177 — Set (or clear) a certificate's expiration timestamp
+    pub fn set_expiration(
+        env: Env,
+        certificate_id: u64,
+        expires_at: Option<u64>,
+    ) -> Result<(), ProvenanceError> {
+        let mut cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        cert.creator.require_auth();
+
+        if let Some(ts) = expires_at {
+            if ts <= env.ledger().timestamp() {
+                return Err(ProvenanceError::InvalidExpiration);
+            }
+        }
+
+        cert.expires_at = expires_at;
+        env.storage().persistent().set(&certificate_id, &cert);
+
+        Ok(())
+    }
+
+    /// #177 — Check whether a certificate has expired
+    pub fn is_certificate_expired(env: Env, certificate_id: u64) -> Result<bool, ProvenanceError> {
+        let cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        Ok(cert
+            .expires_at
+            .map_or(false, |ts| env.ledger().timestamp() > ts))
+    }
+
+    /// #177 — Renew an expired (or soon-to-expire) certificate with a new expiration
+    pub fn renew_certificate(
+        env: Env,
+        certificate_id: u64,
+        new_expires_at: u64,
+    ) -> Result<(), ProvenanceError> {
+        let mut cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        cert.creator.require_auth();
+
+        if new_expires_at <= env.ledger().timestamp() {
+            return Err(ProvenanceError::InvalidExpiration);
+        }
+
+        cert.expires_at = Some(new_expires_at);
+        let renewed_by = cert.creator.clone();
+        env.storage().persistent().set(&certificate_id, &cert);
+
+        CertificateRenewed {
+            certificate_id,
+            renewed_by,
+            new_expires_at,
+        }
+        .emit(&env);
+
+        Ok(())
+    }
+
+    /// #177 — Emit a warning event if the certificate expires within `warning_window` seconds.
+    /// Returns true if a warning was emitted.
+    pub fn check_expiration_warning(
+        env: Env,
+        certificate_id: u64,
+        warning_window: u64,
+    ) -> Result<bool, ProvenanceError> {
+        let cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        let now = env.ledger().timestamp();
+        if let Some(expires_at) = cert.expires_at {
+            if expires_at > now && expires_at - now <= warning_window {
+                CertificateExpirationWarning {
+                    certificate_id,
+                    owner: cert.creator,
+                    expires_at,
+                }
+                .emit(&env);
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
     }
 
     /// #172 — Transfer certificate ownership to a new address
@@ -367,13 +491,16 @@ impl ProvenanceContract {
         let mut count = 0u32;
         let mut skipped = 0u32;
 
+        let now = env.ledger().timestamp();
         let mut i = total_certs;
         while i > 0 && count < limit {
-            if let Ok(cert) = env.storage()
+            if let Some(cert) = env.storage()
                 .persistent()
                 .get::<u64, ProvenanceCert>(&i)
             {
-                if cert.timestamp >= start_time && cert.timestamp <= end_time {
+                // #177 — filter expired certificates out of default queries
+                let expired = cert.expires_at.map_or(false, |ts| now > ts);
+                if !expired && cert.timestamp >= start_time && cert.timestamp <= end_time {
                     if skipped >= offset {
                         results.push_back((i, cert));
                         count += 1;
@@ -439,6 +566,7 @@ impl ProvenanceContract {
                 revoked: false,
                 revocation_reason: None,
                 revocation_timestamp: None,
+                expires_at: None,
             };
             env.storage().persistent().set(&id, &cert);
             env.storage().persistent().set(&mani_key, &id);

--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -14,6 +14,7 @@ pub enum ProvenanceError {
     BatchSizeExceeded = 4,
     UnauthorizedRevocation = 5,
     InvalidExpiration = 6,
+    CircularReference = 7,
 }
 
 // #171 — Revocation reason
@@ -34,6 +35,15 @@ pub enum VerificationLevel {
     Standard = 1,
     Premium = 2,
     Enterprise = 3,
+}
+
+// #178 — Relation to another certificate
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CertificateRelation {
+    Parent(u64),
+    Child(u64),
+    Sibling(u64),
 }
 
 // #14 — String fields (was Bytes)
@@ -151,6 +161,16 @@ pub struct VerificationLevelUpdated {
     pub new_level: VerificationLevel,
 }
 
+// #178 — Certificates linked event
+#[contractevent]
+pub struct CertificatesLinked {
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub related_id: u64,
+    pub relation: CertificateRelation,
+}
+
 #[contract]
 pub struct ProvenanceContract;
 
@@ -167,6 +187,60 @@ fn calculate_verification_level(
     } else {
         VerificationLevel::Basic
     }
+}
+
+// #178 — the id embedded in a CertificateRelation
+fn relation_target(relation: CertificateRelation) -> u64 {
+    match relation {
+        CertificateRelation::Parent(id) => id,
+        CertificateRelation::Child(id) => id,
+        CertificateRelation::Sibling(id) => id,
+    }
+}
+
+// #178 — the reciprocal relation to store on the related certificate
+fn reciprocal_relation(relation: CertificateRelation, self_id: u64) -> CertificateRelation {
+    match relation {
+        CertificateRelation::Parent(_) => CertificateRelation::Child(self_id),
+        CertificateRelation::Child(_) => CertificateRelation::Parent(self_id),
+        CertificateRelation::Sibling(_) => CertificateRelation::Sibling(self_id),
+    }
+}
+
+// #178 — bounded walk up the Parent chain to detect a would-be cycle before
+// linking `start_id` as a child of `related_id`. Depth is capped so the
+// check stays gas-bounded regardless of how deep an existing chain is.
+fn creates_cycle(env: &Env, start_id: u64, target_id: u64) -> bool {
+    const MAX_DEPTH: u32 = 20;
+    let links_key = symbol_short!("LINKS");
+    let mut current = start_id;
+
+    for _ in 0..MAX_DEPTH {
+        if current == target_id {
+            return true;
+        }
+        let key = (links_key, current);
+        let links: Vec<CertificateRelation> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new());
+
+        let mut next: Option<u64> = None;
+        for relation in links.iter() {
+            if let CertificateRelation::Parent(parent_id) = relation {
+                next = Some(parent_id);
+                break;
+            }
+        }
+
+        match next {
+            Some(parent_id) => current = parent_id,
+            None => return false,
+        }
+    }
+
+    false
 }
 
 #[contractimpl]
@@ -493,6 +567,93 @@ impl ProvenanceContract {
         }
 
         results
+    }
+
+    /// #178 — Link two certificates together (parent/child/sibling). The link is
+    /// stored on both certificates as reciprocal relations. Requires auth from
+    /// `certificate_id`'s creator.
+    pub fn link_certificates(
+        env: Env,
+        certificate_id: u64,
+        relation: CertificateRelation,
+    ) -> Result<(), ProvenanceError> {
+        let related_id = relation_target(relation);
+
+        if certificate_id == related_id {
+            return Err(ProvenanceError::CircularReference);
+        }
+
+        let cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+        cert.creator.require_auth();
+
+        if !env.storage().persistent().has(&related_id) {
+            return Err(ProvenanceError::CertificateNotFound);
+        }
+
+        if let CertificateRelation::Parent(parent_id) = relation {
+            // Linking certificate_id as a child of parent_id — reject if
+            // parent_id is already a descendant of certificate_id.
+            if creates_cycle(&env, parent_id, certificate_id) {
+                return Err(ProvenanceError::CircularReference);
+            }
+        }
+        if let CertificateRelation::Child(child_id) = relation {
+            // Linking certificate_id as a parent of child_id — reject if
+            // certificate_id is already a descendant of child_id.
+            if creates_cycle(&env, certificate_id, child_id) {
+                return Err(ProvenanceError::CircularReference);
+            }
+        }
+
+        let links_key = symbol_short!("LINKS");
+
+        let key_a = (links_key, certificate_id);
+        let mut links_a: Vec<CertificateRelation> = env
+            .storage()
+            .persistent()
+            .get(&key_a)
+            .unwrap_or(Vec::new());
+        links_a.push_back(relation);
+        env.storage().persistent().set(&key_a, &links_a);
+
+        let key_b = (links_key, related_id);
+        let mut links_b: Vec<CertificateRelation> = env
+            .storage()
+            .persistent()
+            .get(&key_b)
+            .unwrap_or(Vec::new());
+        links_b.push_back(reciprocal_relation(relation, certificate_id));
+        env.storage().persistent().set(&key_b, &links_b);
+
+        CertificatesLinked {
+            certificate_id,
+            related_id,
+            relation,
+        }
+        .emit(&env);
+
+        Ok(())
+    }
+
+    /// #178 — Query the certificates linked to a given certificate
+    pub fn get_linked_certificates(
+        env: Env,
+        certificate_id: u64,
+    ) -> Result<Vec<CertificateRelation>, ProvenanceError> {
+        if !env.storage().persistent().has(&certificate_id) {
+            return Err(ProvenanceError::CertificateNotFound);
+        }
+
+        let links_key = symbol_short!("LINKS");
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&(links_key, certificate_id))
+            .unwrap_or(Vec::new()))
     }
 
     /// #172 — Transfer certificate ownership to a new address

--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -26,6 +26,16 @@ pub enum RevocationReason {
     ContractualViolation = 4,
 }
 
+// #176 — Verification badge level
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum VerificationLevel {
+    Basic = 0,
+    Standard = 1,
+    Premium = 2,
+    Enterprise = 3,
+}
+
 // #14 — String fields (was Bytes)
 #[contracttype]
 pub struct ProvenanceCert {
@@ -39,6 +49,8 @@ pub struct ProvenanceCert {
     pub revocation_timestamp: Option<u64>,
     // #177 — optional expiration
     pub expires_at:       Option<u64>,
+    // #176 — verification thoroughness badge
+    pub verification_level: VerificationLevel,
 }
 
 // #173 — Certificate metadata with version tracking
@@ -129,8 +141,33 @@ pub struct CertificateExpirationWarning {
     pub expires_at: u64,
 }
 
+// #176 — Verification level updated event
+#[contractevent]
+pub struct VerificationLevelUpdated {
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub updated_by: Address,
+    pub new_level: VerificationLevel,
+}
+
 #[contract]
 pub struct ProvenanceContract;
+
+// #176 — Basic level unless all three verification inputs are populated;
+// Premium/Enterprise require an explicit oracle upgrade via set_verification_level,
+// reflecting off-chain provider-reputation checks beyond what mint parameters convey.
+fn calculate_verification_level(
+    storage_ref: &String,
+    manifest_hash: &String,
+    attestation_hash: &String,
+) -> VerificationLevel {
+    if storage_ref.len() > 0 && manifest_hash.len() > 0 && attestation_hash.len() > 0 {
+        VerificationLevel::Standard
+    } else {
+        VerificationLevel::Basic
+    }
+}
 
 #[contractimpl]
 impl ProvenanceContract {
@@ -187,6 +224,9 @@ impl ProvenanceContract {
             + 1;
         env.storage().persistent().set(&cnt_key, &id);
 
+        let verification_level =
+            calculate_verification_level(&storage_ref, &manifest_hash, &attestation_hash);
+
         let cert = ProvenanceCert {
             storage_ref,
             manifest_hash: manifest_hash.clone(),
@@ -197,6 +237,7 @@ impl ProvenanceContract {
             revocation_reason: None,
             revocation_timestamp: None,
             expires_at: None,
+            verification_level,
         };
         env.storage().persistent().set(&id, &cert);
 
@@ -375,6 +416,83 @@ impl ProvenanceContract {
         }
 
         Ok(false)
+    }
+
+    /// #176 — Oracle-gated upgrade of a certificate's verification level,
+    /// reflecting off-chain provider-reputation vetting.
+    pub fn set_verification_level(
+        env: Env,
+        certificate_id: u64,
+        level: VerificationLevel,
+    ) -> Result<(), ProvenanceError> {
+        let oracle: Address = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("ORACLE"))
+            .expect("Not initialized");
+        oracle.require_auth();
+
+        let mut cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        cert.verification_level = level;
+        env.storage().persistent().set(&certificate_id, &cert);
+
+        VerificationLevelUpdated {
+            certificate_id,
+            updated_by: oracle,
+            new_level: level,
+        }
+        .emit(&env);
+
+        Ok(())
+    }
+
+    /// #176 — Get a certificate's verification level
+    pub fn get_verification_level(
+        env: Env,
+        certificate_id: u64,
+    ) -> Result<VerificationLevel, ProvenanceError> {
+        env.storage()
+            .persistent()
+            .get(&certificate_id)
+            .map(|cert: ProvenanceCert| cert.verification_level)
+            .ok_or(ProvenanceError::CertificateNotFound)
+    }
+
+    /// #176 — Query certificates matching a given verification level
+    pub fn get_certificates_by_verification_level(
+        env: Env,
+        level: VerificationLevel,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<(u64, ProvenanceCert)> {
+        let cnt_key = symbol_short!("CERT_CNT");
+        let total_certs: u64 = env.storage().persistent().get(&cnt_key).unwrap_or(0u64);
+
+        let mut results: Vec<(u64, ProvenanceCert)> = Vec::new();
+        let mut count = 0u32;
+        let mut skipped = 0u32;
+
+        let mut i = total_certs;
+        while i > 0 && count < limit {
+            if let Some(cert) = env.storage().persistent().get::<u64, ProvenanceCert>(&i) {
+                if cert.verification_level == level {
+                    if skipped >= offset {
+                        results.push_back((i, cert));
+                        count += 1;
+                    } else {
+                        skipped += 1;
+                    }
+                }
+            }
+            i -= 1;
+        }
+
+        results
     }
 
     /// #172 — Transfer certificate ownership to a new address
@@ -557,6 +675,9 @@ impl ProvenanceContract {
                 + 1;
             env.storage().persistent().set(&cnt_key, &id);
 
+            let verification_level =
+                calculate_verification_level(&storage_ref, &manifest_hash, &attestation_hash);
+
             let cert = ProvenanceCert {
                 storage_ref,
                 manifest_hash: manifest_hash.clone(),
@@ -567,6 +688,7 @@ impl ProvenanceContract {
                 revocation_reason: None,
                 revocation_timestamp: None,
                 expires_at: None,
+                verification_level,
             };
             env.storage().persistent().set(&id, &cert);
             env.storage().persistent().set(&mani_key, &id);

--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -4,6 +4,9 @@ use soroban_sdk::{
     symbol_short, Address, Env, String, Vec, Map,
 };
 
+// #179 — bucket width for the minting time series / velocity stats
+const DAY_SECONDS: u64 = 86400;
+
 // #16 — typed error enum
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -78,6 +81,21 @@ pub struct MetadataVersion {
     pub display_name: String,
     pub description: String,
     pub updated_at: u64,
+}
+
+// #179 — Aggregate certificate statistics
+#[contracttype]
+pub struct CertificateStats {
+    pub total_certificates: u64,
+    pub certificates_today: u64,
+}
+
+// #179 — A single point in the daily minting time series
+#[contracttype]
+pub struct TimeSeriesPoint {
+    pub day: u64,
+    pub period_start: u64,
+    pub count: u64,
 }
 
 // #15 — typed contract event
@@ -317,6 +335,16 @@ impl ProvenanceContract {
 
         // #13 — store manifest → id mapping
         env.storage().persistent().set(&mani_key, &id);
+
+        // #179 — creator / daily minting counters
+        let creator_key = (symbol_short!("CCNT"), to.clone());
+        let creator_count: u64 = env.storage().persistent().get(&creator_key).unwrap_or(0u64);
+        env.storage().persistent().set(&creator_key, &(creator_count + 1));
+
+        let day = env.ledger().timestamp() / DAY_SECONDS;
+        let daily_key = (symbol_short!("DAILY"), day);
+        let daily_count: u64 = env.storage().persistent().get(&daily_key).unwrap_or(0u64);
+        env.storage().persistent().set(&daily_key, &(daily_count + 1));
 
         // #15 — emit typed event
         CertificateMinted {
@@ -856,6 +884,21 @@ impl ProvenanceContract {
             certificate_ids.push_back(id);
         }
 
+        // #179 — creator / daily minting counters
+        let minted_count = certificate_ids.len() as u64;
+        let creator_key = (symbol_short!("CCNT"), to.clone());
+        let creator_count: u64 = env.storage().persistent().get(&creator_key).unwrap_or(0u64);
+        env.storage()
+            .persistent()
+            .set(&creator_key, &(creator_count + minted_count));
+
+        let day = env.ledger().timestamp() / DAY_SECONDS;
+        let daily_key = (symbol_short!("DAILY"), day);
+        let daily_count: u64 = env.storage().persistent().get(&daily_key).unwrap_or(0u64);
+        env.storage()
+            .persistent()
+            .set(&daily_key, &(daily_count + minted_count));
+
         BatchMinted {
             owner: to,
             certificate_ids: certificate_ids.clone(),
@@ -864,6 +907,63 @@ impl ProvenanceContract {
         .emit(&env);
 
         Ok(certificate_ids)
+    }
+
+    /// #179 — Aggregate certificate statistics: total minted, and minted today
+    pub fn get_certificate_stats(env: Env) -> CertificateStats {
+        let total_certificates: u64 = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("CERT_CNT"))
+            .unwrap_or(0u64);
+
+        let day = env.ledger().timestamp() / DAY_SECONDS;
+        let certificates_today: u64 = env
+            .storage()
+            .persistent()
+            .get(&(symbol_short!("DAILY"), day))
+            .unwrap_or(0u64);
+
+        CertificateStats {
+            total_certificates,
+            certificates_today,
+        }
+    }
+
+    /// #179 — Number of certificates minted to a given creator
+    pub fn get_creator_certificate_count(env: Env, creator: Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&(symbol_short!("CCNT"), creator))
+            .unwrap_or(0u64)
+    }
+
+    /// #179 — Daily minting counts (a minting-velocity time series) for the
+    /// inclusive day range [start_day, end_day], capped at 366 points.
+    pub fn get_minting_time_series(
+        env: Env,
+        start_day: u64,
+        end_day: u64,
+    ) -> Vec<TimeSeriesPoint> {
+        const MAX_POINTS: u64 = 366;
+        let day_count = end_day.saturating_sub(start_day).saturating_add(1).min(MAX_POINTS);
+
+        let mut points: Vec<TimeSeriesPoint> = Vec::new();
+        for offset in 0..day_count {
+            let day = start_day + offset;
+            let count: u64 = env
+                .storage()
+                .persistent()
+                .get(&(symbol_short!("DAILY"), day))
+                .unwrap_or(0u64);
+            points.push_back(TimeSeriesPoint {
+                day,
+                period_start: day * DAY_SECONDS,
+                count,
+            });
+        }
+
+        points
     }
 }
 

--- a/contracts/provenance/src/lib.rs
+++ b/contracts/provenance/src/lib.rs
@@ -12,6 +12,17 @@ pub enum ProvenanceError {
     Unauthorized = 2,
     DuplicateCertificate = 3,
     BatchSizeExceeded = 4,
+    UnauthorizedRevocation = 5,
+}
+
+// #171 — Revocation reason
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RevocationReason {
+    FraudulentContent = 1,
+    LegalRequirement = 2,
+    CreatorRequest = 3,
+    ContractualViolation = 4,
 }
 
 // #14 — String fields (was Bytes)
@@ -83,6 +94,16 @@ pub struct BatchMinted {
     pub owner: Address,
     pub certificate_ids: Vec<u64>,
     pub count: u32,
+}
+
+// #171 — Revocation event
+#[contractevent]
+pub struct CertificateRevoked {
+    #[topic]
+    pub certificate_id: u64,
+    #[topic]
+    pub owner: Address,
+    pub reason: String,
 }
 
 #[contract]
@@ -177,6 +198,58 @@ impl ProvenanceContract {
         env.storage()
             .persistent()
             .get(&id)
+            .ok_or(ProvenanceError::CertificateNotFound)
+    }
+
+    /// #171 — Revoke a certificate. Only the oracle may call this.
+    pub fn revoke_certificate(
+        env: Env,
+        certificate_id: u64,
+        reason: RevocationReason,
+    ) -> Result<(), ProvenanceError> {
+        let oracle: Address = env
+            .storage()
+            .persistent()
+            .get(&symbol_short!("ORACLE"))
+            .expect("Not initialized");
+        oracle.require_auth();
+
+        let mut cert: ProvenanceCert = env
+            .storage()
+            .persistent()
+            .get(&certificate_id)
+            .ok_or(ProvenanceError::CertificateNotFound)?;
+
+        cert.revoked = true;
+        cert.revocation_reason = Some(reason.clone());
+        cert.revocation_timestamp = Some(env.ledger().timestamp());
+        let owner = cert.creator.clone();
+
+        env.storage().persistent().set(&certificate_id, &cert);
+
+        let reason_str = match reason {
+            RevocationReason::FraudulentContent => String::from_str(&env, "fraudulent_content"),
+            RevocationReason::LegalRequirement => String::from_str(&env, "legal_requirement"),
+            RevocationReason::CreatorRequest => String::from_str(&env, "creator_request"),
+            RevocationReason::ContractualViolation => String::from_str(&env, "contractual_violation"),
+        };
+
+        CertificateRevoked {
+            certificate_id,
+            owner,
+            reason: reason_str,
+        }
+        .emit(&env);
+
+        Ok(())
+    }
+
+    /// #171 — Check whether a certificate has been revoked
+    pub fn is_certificate_revoked(env: Env, certificate_id: u64) -> Result<bool, ProvenanceError> {
+        env.storage()
+            .persistent()
+            .get(&certificate_id)
+            .map(|cert: ProvenanceCert| cert.revoked)
             .ok_or(ProvenanceError::CertificateNotFound)
     }
 
@@ -363,6 +436,9 @@ impl ProvenanceContract {
                 attestation_hash,
                 creator: to.clone(),
                 timestamp: env.ledger().timestamp(),
+                revoked: false,
+                revocation_reason: None,
+                revocation_timestamp: None,
             };
             env.storage().persistent().set(&id, &cert);
             env.storage().persistent().set(&mani_key, &id);

--- a/contracts/provenance/src/test.rs
+++ b/contracts/provenance/src/test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{ProvenanceContract, ProvenanceContractClient, ProvenanceError, RevocationReason};
-    use soroban_sdk::{testutils::Address as _, Env, String};
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Env, String};
 
     fn s(env: &Env, v: &str) -> String {
         String::from_str(env, v)
@@ -136,6 +136,118 @@ mod tests {
                 .unwrap(),
             ProvenanceError::CertificateNotFound
         );
+    }
+
+    // --- Issue #177 --- Certificate Expiration
+
+    #[test]
+    fn test_certificate_not_expired_by_default() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_exp1"), &s(&env, "ahash"), &owner);
+        assert!(!client.is_certificate_expired(&id));
+    }
+
+    #[test]
+    fn test_set_expiration_and_expire() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_exp2"), &s(&env, "ahash"), &owner);
+        let now = env.ledger().timestamp();
+        client.set_expiration(&id, &Some(now + 100));
+        assert!(!client.is_certificate_expired(&id));
+
+        env.ledger().with_mut(|li| li.timestamp = now + 200);
+        assert!(client.is_certificate_expired(&id));
+    }
+
+    #[test]
+    fn test_set_expiration_in_past_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_exp3"), &s(&env, "ahash"), &owner);
+        let now = env.ledger().timestamp();
+        assert_eq!(
+            client.try_set_expiration(&id, &Some(now)).unwrap_err().unwrap(),
+            ProvenanceError::InvalidExpiration
+        );
+    }
+
+    #[test]
+    fn test_renew_certificate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_exp4"), &s(&env, "ahash"), &owner);
+        let now = env.ledger().timestamp();
+        client.set_expiration(&id, &Some(now + 10));
+        env.ledger().with_mut(|li| li.timestamp = now + 20);
+        assert!(client.is_certificate_expired(&id));
+
+        client.renew_certificate(&id, &(now + 1000));
+        assert!(!client.is_certificate_expired(&id));
+    }
+
+    #[test]
+    fn test_check_expiration_warning() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_exp5"), &s(&env, "ahash"), &owner);
+        let now = env.ledger().timestamp();
+        client.set_expiration(&id, &Some(now + 50));
+
+        assert!(!client.check_expiration_warning(&id, &10));
+        assert!(client.check_expiration_warning(&id, &100));
+    }
+
+    #[test]
+    fn test_expired_certificate_filtered_from_time_range_query() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id1 = client.mint(&s(&env, "sid"), &s(&env, "mhash_exp6"), &s(&env, "ahash"), &owner);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_exp7"), &s(&env, "ahash"), &owner);
+
+        let now = env.ledger().timestamp();
+        client.set_expiration(&id1, &Some(now + 10));
+        env.ledger().with_mut(|li| li.timestamp = now + 20);
+
+        let results = client.get_certificates_by_time_range(&0, &(now + 1000), &0, &10);
+        assert_eq!(results.len(), 1);
     }
 
     // --- Issue #172 --- Certificate Transfer

--- a/contracts/provenance/src/test.rs
+++ b/contracts/provenance/src/test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        ProvenanceContract, ProvenanceContractClient, ProvenanceError, RevocationReason,
-        VerificationLevel,
+        CertificateRelation, ProvenanceContract, ProvenanceContractClient, ProvenanceError,
+        RevocationReason, VerificationLevel,
     };
     use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Env, String};
 
@@ -333,6 +333,112 @@ mod tests {
         assert_eq!(
             client.try_get_verification_level(&999u64).unwrap_err().unwrap(),
             ProvenanceError::CertificateNotFound
+        );
+    }
+
+    // --- Issue #178 --- Certificate Linking
+
+    #[test]
+    fn test_link_parent_child_reciprocal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let a = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk1"), &s(&env, "ahash"), &owner);
+        let b = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk2"), &s(&env, "ahash"), &owner);
+
+        client.link_certificates(&b, &CertificateRelation::Parent(a));
+
+        let b_links = client.get_linked_certificates(&b);
+        assert_eq!(b_links.len(), 1);
+        assert_eq!(b_links.get_unchecked(0), CertificateRelation::Parent(a));
+
+        let a_links = client.get_linked_certificates(&a);
+        assert_eq!(a_links.len(), 1);
+        assert_eq!(a_links.get_unchecked(0), CertificateRelation::Child(b));
+    }
+
+    #[test]
+    fn test_link_sibling_reciprocal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let c = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk3"), &s(&env, "ahash"), &owner);
+        let d = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk4"), &s(&env, "ahash"), &owner);
+
+        client.link_certificates(&c, &CertificateRelation::Sibling(d));
+
+        assert_eq!(client.get_linked_certificates(&c).get_unchecked(0), CertificateRelation::Sibling(d));
+        assert_eq!(client.get_linked_certificates(&d).get_unchecked(0), CertificateRelation::Sibling(c));
+    }
+
+    #[test]
+    fn test_link_self_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let a = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk5"), &s(&env, "ahash"), &owner);
+
+        assert_eq!(
+            client.try_link_certificates(&a, &CertificateRelation::Parent(a)).unwrap_err().unwrap(),
+            ProvenanceError::CircularReference
+        );
+    }
+
+    #[test]
+    fn test_link_nonexistent_related_certificate_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let a = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk6"), &s(&env, "ahash"), &owner);
+
+        assert_eq!(
+            client.try_link_certificates(&a, &CertificateRelation::Parent(999u64)).unwrap_err().unwrap(),
+            ProvenanceError::CertificateNotFound
+        );
+    }
+
+    #[test]
+    fn test_link_circular_reference_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let a = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk7"), &s(&env, "ahash"), &owner);
+        let b = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk8"), &s(&env, "ahash"), &owner);
+        let c = client.mint(&s(&env, "sid"), &s(&env, "mhash_lnk9"), &s(&env, "ahash"), &owner);
+
+        // chain: C -> parent B -> parent A
+        client.link_certificates(&b, &CertificateRelation::Parent(a));
+        client.link_certificates(&c, &CertificateRelation::Parent(b));
+
+        // A -> parent C would close the loop A -> C -> B -> A
+        assert_eq!(
+            client.try_link_certificates(&a, &CertificateRelation::Parent(c)).unwrap_err().unwrap(),
+            ProvenanceError::CircularReference
         );
     }
 

--- a/contracts/provenance/src/test.rs
+++ b/contracts/provenance/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{ProvenanceContract, ProvenanceContractClient, ProvenanceError};
+    use crate::{ProvenanceContract, ProvenanceContractClient, ProvenanceError, RevocationReason};
     use soroban_sdk::{testutils::Address as _, Env, String};
 
     fn s(env: &Env, v: &str) -> String {
@@ -95,6 +95,47 @@ mod tests {
         assert!(client
             .try_mint(&s(&env, "sid"), &s(&env, "mhash"), &s(&env, "ahash"), &to)
             .is_err());
+    }
+
+    // --- Issue #171 --- Certificate Revocation
+
+    #[test]
+    fn test_revoke_certificate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_rev1"), &s(&env, "ahash"), &owner);
+        assert!(!client.is_certificate_revoked(&id));
+
+        client.revoke_certificate(&id, &RevocationReason::FraudulentContent);
+
+        assert!(client.is_certificate_revoked(&id));
+        let cert = client.get_certificate(&id).unwrap();
+        assert!(cert.revoked);
+        assert_eq!(cert.revocation_reason, Some(RevocationReason::FraudulentContent));
+    }
+
+    #[test]
+    fn test_revoke_nonexistent_certificate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        assert_eq!(
+            client
+                .try_revoke_certificate(&999u64, &RevocationReason::LegalRequirement)
+                .unwrap_err()
+                .unwrap(),
+            ProvenanceError::CertificateNotFound
+        );
     }
 
     // --- Issue #172 --- Certificate Transfer

--- a/contracts/provenance/src/test.rs
+++ b/contracts/provenance/src/test.rs
@@ -442,6 +442,88 @@ mod tests {
         );
     }
 
+    // --- Issue #179 --- Certificate Statistics and Analytics
+
+    #[test]
+    fn test_get_certificate_stats() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat1"), &s(&env, "ahash"), &owner);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat2"), &s(&env, "ahash"), &owner);
+
+        let stats = client.get_certificate_stats();
+        assert_eq!(stats.total_certificates, 2);
+        assert_eq!(stats.certificates_today, 2);
+    }
+
+    #[test]
+    fn test_get_creator_certificate_count() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner1 = soroban_sdk::Address::generate(&env);
+        let owner2 = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat3"), &s(&env, "ahash"), &owner1);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat4"), &s(&env, "ahash"), &owner1);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat5"), &s(&env, "ahash"), &owner2);
+
+        assert_eq!(client.get_creator_certificate_count(&owner1), 2);
+        assert_eq!(client.get_creator_certificate_count(&owner2), 1);
+    }
+
+    #[test]
+    fn test_get_creator_certificate_count_includes_batch() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let storage_refs = soroban_sdk::vec![&env, s(&env, "sid1"), s(&env, "sid2")];
+        let manifest_hashes = soroban_sdk::vec![&env, s(&env, "mhash_stat6"), s(&env, "mhash_stat7")];
+        let attestation_hashes = soroban_sdk::vec![&env, s(&env, "ah1"), s(&env, "ah2")];
+        client.mint_batch(&storage_refs, &manifest_hashes, &attestation_hashes, &owner);
+
+        assert_eq!(client.get_creator_certificate_count(&owner), 2);
+        let stats = client.get_certificate_stats();
+        assert_eq!(stats.total_certificates, 2);
+        assert_eq!(stats.certificates_today, 2);
+    }
+
+    #[test]
+    fn test_get_minting_time_series() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat8"), &s(&env, "ahash"), &owner);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_stat9"), &s(&env, "ahash"), &owner);
+
+        let today = env.ledger().timestamp() / 86400;
+        let series = client.get_minting_time_series(&today, &today);
+        assert_eq!(series.len(), 1);
+        assert_eq!(series.get_unchecked(0).count, 2);
+
+        let empty_series = client.get_minting_time_series(&(today + 1), &(today + 1));
+        assert_eq!(empty_series.get_unchecked(0).count, 0);
+    }
+
     // --- Issue #172 --- Certificate Transfer
 
     #[test]

--- a/contracts/provenance/src/test.rs
+++ b/contracts/provenance/src/test.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use crate::{ProvenanceContract, ProvenanceContractClient, ProvenanceError, RevocationReason};
+    use crate::{
+        ProvenanceContract, ProvenanceContractClient, ProvenanceError, RevocationReason,
+        VerificationLevel,
+    };
     use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Env, String};
 
     fn s(env: &Env, v: &str) -> String {
@@ -248,6 +251,89 @@ mod tests {
 
         let results = client.get_certificates_by_time_range(&0, &(now + 1000), &0, &10);
         assert_eq!(results.len(), 1);
+    }
+
+    // --- Issue #176 --- Verification Badge Levels
+
+    #[test]
+    fn test_default_verification_level_is_standard() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_lvl1"), &s(&env, "ahash"), &owner);
+        assert_eq!(client.get_verification_level(&id), VerificationLevel::Standard);
+    }
+
+    #[test]
+    fn test_basic_verification_level_when_fields_incomplete() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_lvl2"), &s(&env, ""), &owner);
+        assert_eq!(client.get_verification_level(&id), VerificationLevel::Basic);
+    }
+
+    #[test]
+    fn test_set_verification_level_by_oracle() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id = client.mint(&s(&env, "sid"), &s(&env, "mhash_lvl3"), &s(&env, "ahash"), &owner);
+        client.set_verification_level(&id, &VerificationLevel::Enterprise);
+        assert_eq!(client.get_verification_level(&id), VerificationLevel::Enterprise);
+    }
+
+    #[test]
+    fn test_get_certificates_by_verification_level() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        let owner = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        let id1 = client.mint(&s(&env, "sid"), &s(&env, "mhash_lvl4"), &s(&env, "ahash"), &owner);
+        client.mint(&s(&env, "sid"), &s(&env, "mhash_lvl5"), &s(&env, "ahash"), &owner);
+        client.set_verification_level(&id1, &VerificationLevel::Premium);
+
+        let results = client.get_certificates_by_verification_level(&VerificationLevel::Premium, &0, &10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results.get_unchecked(0).0, id1);
+
+        let standard_results =
+            client.get_certificates_by_verification_level(&VerificationLevel::Standard, &0, &10);
+        assert_eq!(standard_results.len(), 1);
+    }
+
+    #[test]
+    fn test_get_verification_level_nonexistent_certificate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, ProvenanceContract);
+        let client = ProvenanceContractClient::new(&env, &cid);
+        let oracle = soroban_sdk::Address::generate(&env);
+        client.initialize(&oracle);
+
+        assert_eq!(
+            client.try_get_verification_level(&999u64).unwrap_err().unwrap(),
+            ProvenanceError::CertificateNotFound
+        );
     }
 
     // --- Issue #172 --- Certificate Transfer


### PR DESCRIPTION
## Summary

Implements four provenance-contract feature requests, each as its own commit, plus one prerequisite fix:

- **fix**: restore certificate revocation lost in a prior merge — a merge of the transfer/metadata/time-range/batch-mint work (#172-#175) was based on a commit predating the revocation feature (#171), silently dropping `RevocationReason`, `revoke_certificate`, `is_certificate_revoked`, and the `CertificateRevoked` event while leaving the `revocation_reason: Option<RevocationReason>` field on `ProvenanceCert` in place. `mint_batch`'s `ProvenanceCert` literal was also missing the revocation fields. Both broke compilation of the `provenance` contract on `main`; this was required before any of the below could be added.
- **#177 — Certificate Expiration Dates**: optional `expires_at` on `ProvenanceCert`; `set_expiration` / `is_certificate_expired` / `renew_certificate` / `check_expiration_warning` (emits `CertificateExpirationWarning`); `get_certificates_by_time_range` now filters out expired certificates by default.
- **#176 — Verification Badge Levels**: `VerificationLevel` enum (Basic/Standard/Premium/Enterprise); calculated at mint time from verification-input completeness; `set_verification_level` (oracle-gated upgrade for Premium/Enterprise, reflecting off-chain provider-reputation checks); `get_verification_level`; `get_certificates_by_verification_level` filter query.
- **#178 — Certificate Linking**: `CertificateRelation` enum (Parent/Child/Sibling); `link_certificates` stores reciprocal relations on both certificates and emits `CertificatesLinked`; `get_linked_certificates` query; circular references are rejected (self-links outright, and Parent/Child links via a bounded ancestor walk).
- **#179 — Certificate Statistics and Analytics**: `get_certificate_stats` (total minted, minted today); `get_creator_certificate_count` (per-creator counts, tracked in `mint` and `mint_batch`); `get_minting_time_series` (daily minting-velocity time series over a day range, capped at 366 points).

Each feature has its own commit on this branch; the fix commit comes first since nothing else compiles without it.

## Test plan

- [ ] `cargo test -p provenance` (added unit tests for revocation restore, expiration, verification levels, linking, and stats — this environment doesn't have a Rust toolchain available so tests are unverified by me; please run in CI)

Closes #176
Closes #177
Closes #178
Closes #179