### PR TITLE
docs: design docs for testing issues #244-#247

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,6 @@
 | [Contract Deployment Process](deployment.md) | Contributors deploying contracts | Prerequisites, network config, step-by-step deploy, initialization, verification, rollback, checklist |
 | [User Guide and Tutorials](user-guide.md) | End users | Getting started, content verification and certificate-viewing walkthroughs, troubleshooting, FAQ |
 | [Architecture Decision Records](adr/README.md) | Contributors, especially anyone touching architecture | Why the system is built the way it is |
+| [Testing Strategy Design Docs](testing/README.md) | Contributors picking up testing work | Contract snapshot testing, chaos engineering, API contract testing, visual regression testing |
 
 Start with the [Developer Onboarding Guide](onboarding.md) if you're new to the project.

--- a/docs/testing/244-visual-regression-testing.md
+++ b/docs/testing/244-visual-regression-testing.md
@@ -1,0 +1,98 @@
+# #244 — Add Visual Regression Testing
+
+**Labels:** testing, frontend, UI · **Priority:** Medium
+
+## Current state
+
+More is already in place than the issue title suggests:
+
+- `frontend/playwright.config.ts` already declares `snapshotDir:
+  "./e2e/snapshots"` and runs 5 projects — `chromium`, `firefox`, `webkit`,
+  `mobile-chrome` (Pixel 5), `mobile-safari` (iPhone 13) — so
+  cross-viewport coverage is already wired at the config level.
+- Five `expect(page).toHaveScreenshot(...)` calls already exist, embedded
+  inside feature specs (`wallet-connection.spec.ts`,
+  `file-upload-verification.spec.ts`, `certificate-viewing.spec.ts`,
+  `search-and-filtering.spec.ts`).
+- Three purpose-built demo routes already exist and are close to ideal
+  component-snapshot targets: `app/skeleton-demo`, `app/stepper-demo`,
+  `app/features-showcase`.
+- No Chromatic, Percy, or Storybook in the repo today.
+
+So the gap isn't "set up visual regression from scratch" — it's
+consolidating the ad-hoc screenshots into a real suite, and closing the
+component-coverage and review-workflow gaps.
+
+## Proposed approach
+
+### Engine: Playwright's built-in `toHaveScreenshot`, not Chromatic/Percy
+
+Both are paid SaaS requiring an account/org signup — out of scope to set up
+unilaterally. Playwright's native comparison is already the tool in use
+(see above), needs no new account, and satisfies every acceptance criterion
+except the specific vendor name. Note this as a deliberate substitution;
+revisit if the team later wants Chromatic's cross-browser cloud rendering
+or its hosted approve/reject UI specifically.
+
+### 1. Dedicated visual-regression suite
+
+New `frontend/e2e/visual-regression.spec.ts` consolidating page-level
+screenshot coverage (landing page, verify flow, certificate detail, batch
+verification, comparison view) instead of leaving it scattered inside
+feature specs — keeps "does this look right" separate from "does this
+function right" so a visual diff doesn't fail a functional test and vice
+versa.
+
+### 2. Component snapshot tests
+
+Point new specs at the existing demo routes plus any component that has
+meaningful visual states not covered by a full-page flow: `app/skeleton-demo`
+(loading states), `app/stepper-demo` (wizard steps), `app/features-showcase`.
+For anything not already exposed via a demo route, add one — cheaper than
+introducing Storybook for a first pass, and keeps the app itself as the
+single rendering source of truth.
+
+### 3. Cross-viewport
+
+Already covered by the 5 existing Playwright projects; the new spec just
+needs to run under all of them (default — no project-specific filtering
+needed unless a component is desktop-only).
+
+### 4. Approve/reject workflow
+
+Snapshots are committed PNGs, which git can diff visually in a PR file view
+but not summarize. Two additions:
+
+- `npx playwright test --update-snapshots` documented in
+  `frontend/README.md` as the accept step for an intentional visual change.
+- CI: on failure, upload the Playwright HTML report (already configured —
+  `playwright-report/`) as a build artifact so a reviewer can open the
+  actual/expected/diff triptych without re-running locally.
+
+### 5. PR review integration
+
+Add a step to the `E2E Tests` job in `.github/workflows/ci.yml` that
+uploads `playwright-report/` via `actions/upload-artifact` on failure, and
+link it from a PR comment (`actions/github-script`, minimal — just posts
+the artifact URL) so a failing visual check is one click from "see the
+diff," not "re-run the suite locally."
+
+## Acceptance criteria mapping
+
+| Criterion | Delivered by |
+|---|---|
+| Chromatic or Percy integration | Substituted with Playwright native (see rationale above) — flag if the team wants the paid alternative instead |
+| Screenshot comparison | `toHaveScreenshot`, consolidated into `visual-regression.spec.ts` |
+| Component snapshot tests | Demo routes (`skeleton-demo`, `stepper-demo`, `features-showcase`) + new ones as needed |
+| Test across viewports | Existing 5 Playwright projects (desktop × 3, mobile × 2) |
+| Approve/reject workflow | `--update-snapshots` + documented process |
+| Integration with PR reviews | CI artifact upload + PR comment link on failure |
+
+## Rollout
+
+1. Consolidate existing scattered screenshots into
+   `e2e/visual-regression.spec.ts`; keep the feature-spec ones only if they
+   assert something spec-specific (e.g. "connected" wallet state).
+2. Add component-level specs against the 3 demo routes.
+3. CI artifact upload + PR comment wiring.
+4. Document the accept workflow in `frontend/README.md`.

--- a/docs/testing/245-api-contract-testing.md
+++ b/docs/testing/245-api-contract-testing.md
@@ -1,0 +1,109 @@
+# #245 — Implement API Contract Testing
+
+**Labels:** testing, backend, api · **Priority:** Medium
+
+## Current API surface
+
+Three Next.js route handlers, all under `frontend/app/api/`:
+
+| Route | Method | Behavior |
+|---|---|---|
+| `/api/health` | `GET` | Static `{ status: "ok", service: "stellarveriphy" }` |
+| `/api/verification` | `POST` | Rate-limited (`lib/security/rateLimiter`), validates body via `lib/security/inputValidation`, audit-logs via `lib/security/auditLogger`; returns `202` with `{ success, data }` or `400`/`429` with `{ success: false, error, ... }` |
+| `/api/csp-report` | `POST` | CSP violation report sink; always `200`/`400` |
+
+There's no OpenAPI spec, no request/response schema validation, no
+versioning, and no mock server today — this issue is greenfield, not a
+retrofit.
+
+## Proposed approach
+
+### 1. Schema-first with zod
+
+Add `zod` (not currently a dependency — `react-hook-form` is used without a
+resolver today). Define request/response schemas once in
+`packages/shared/` (already the cross-package shared-types location used by
+both frontend and, in principle, any future service) so the contract has a
+single source of truth:
+
+```
+packages/shared/contracts/
+  health.ts          // HealthResponseSchema
+  verification.ts     // VerificationRequestSchema, VerificationResponseSchema
+  csp-report.ts        // CspReportSchema
+```
+
+Each route handler validates against its schema (replacing/wrapping the
+existing hand-rolled `validateVerificationRequest`) so the implementation
+can never silently drift from the published contract.
+
+### 2. OpenAPI spec generation
+
+Generate `docs/api/openapi.yaml` from the zod schemas via
+`@asteasolutions/zod-to-openapi`, wired to a small script
+(`frontend/scripts/generate-openapi.ts`) run in CI to fail if the checked-in
+spec is stale relative to the schemas (`git diff --exit-code` after
+regenerating).
+
+### 3. Contract validation tests
+
+Next.js route handlers are plain functions — no server needed to test them.
+`frontend/app/api/**/__tests__/*.contract.test.ts` imports the handler
+directly, constructs a `NextRequest`, and asserts the response body against
+the same zod schema used to generate the OpenAPI spec (so the test can never
+diverge from the documented contract — it's checking the same schema
+object, not a hand-copied expectation).
+
+### 4. Version compatibility checks
+
+Routes are currently unversioned. Introduce an `X-API-Version` response
+header (default `1`) and a compatibility test suite that snapshots the
+response shape per version — if a field is removed or a type narrows for
+`v1` consumers, the test fails. This is deliberately lighter than a
+path-based `/api/v1/...` rewrite, which would be a breaking change to the
+one existing consumer (the frontend itself) for no current benefit.
+
+### 5. Mock server for development
+
+`msw` (Mock Service Worker, Node mode) at `frontend/mocks/server.ts`,
+handlers built directly from the same zod schemas (via
+`zod-to-json-schema` + a fixture generator, or hand-written fixtures per
+schema). Lets frontend feature work proceed against realistic
+`/api/verification` responses without a live backend, and doubles as the
+provider-side fixture source for #4 below.
+
+### 6. Consumer-driven contracts
+
+Full Pact (with a broker service) is heavier than this project needs today.
+Lighter equivalent: shared fixtures in `packages/shared/contracts/fixtures/`
+that both sides consume —
+
+- **Consumer test** (`frontend/services/__tests__/*.contract.test.ts`):
+  the service layer (e.g. `certificateVerificationService.ts`) is tested
+  against the fixture responses, proving it can parse what the fixture
+  claims the provider returns.
+- **Provider test** (the route handler contract tests from #3): proves the
+  real handler's output matches the same fixture shape.
+
+If either side changes independently, whichever test reads the stale
+fixture fails — same guarantee Pact gives, without standing up a broker.
+
+## Acceptance criteria mapping
+
+| Criterion | Delivered by |
+|---|---|
+| OpenAPI/Swagger spec generation | zod → `zod-to-openapi` → `docs/api/openapi.yaml`, CI-checked for staleness |
+| Contract validation tests | `app/api/**/__tests__/*.contract.test.ts` against the same zod schemas |
+| Version compatibility checks | `X-API-Version` header + per-version response-shape snapshot tests |
+| Mock server for development | `msw` node server in `frontend/mocks/`, schema-driven |
+| Consumer-driven contracts | Shared fixtures in `packages/shared/contracts/fixtures/`, consumed by both service-layer and route-handler tests |
+
+## Rollout
+
+1. Add `zod`, define schemas in `packages/shared/contracts/` for the 3
+   existing routes.
+2. Wire route handlers to validate against them.
+3. Contract validation tests per route.
+4. OpenAPI generation script + CI staleness check.
+5. `msw` mock server + shared fixtures; consumer tests on the service layer.
+6. `X-API-Version` header + compatibility snapshots.

--- a/docs/testing/246-chaos-engineering-tests.md
+++ b/docs/testing/246-chaos-engineering-tests.md
@@ -1,0 +1,89 @@
+# #246 — Add Chaos Engineering Tests
+
+**Labels:** testing, reliability · **Priority:** Low
+
+## Goal
+
+Verify the system degrades predictably — instead of corrupting state or
+hanging — when a dependency misbehaves: a cross-contract call panics, an RPC
+call drops, a wallet extension stalls, or a request times out mid-flight.
+
+## Where "chaos" actually applies here
+
+Stellar-Veriphy has no long-lived servers or queues to kill — the failure
+surface is (a) cross-contract calls between `oracle` → `registry` /
+`provenance`, and (b) the frontend's calls out to Soroban RPC and the
+Freighter wallet extension. The acceptance criteria map onto those two
+tiers rather than infra-style chaos (pod kills, network partitions).
+
+### Tier 1 — contract-level fault injection
+
+`contracts/oracle/src/test.rs` already has the right pattern to extend: it
+defines `mock_registry` (happy path) and `reject_registry` (always denies)
+test-only contracts that stand in for `registry` when exercising `oracle`.
+Add siblings for the failure modes the acceptance criteria call for:
+
+- `panicking_registry` — a mock whose functions panic, simulating a
+  dependent contract erroring mid-call. Assert the caller's storage is
+  unchanged afterward (Soroban transactions are atomic, so this should
+  hold — the test exists to *prove* it, and to catch any future code path
+  that writes to storage before making the cross-contract call).
+- `malformed_registry` — returns a `bool`/type that's technically valid but
+  semantically wrong (e.g. `is_provider` always `true` while
+  `is_tee_hash_approved` always `false`), to check the caller doesn't
+  silently accept an inconsistent combination.
+- **Partial batch failure**: `oracle` has a batch request path — add a test
+  where one item in a batch fails validation and assert the others still
+  succeed (or the whole batch atomically rolls back, whichever is the
+  intended contract) rather than leaving partial state.
+
+There's no real "timeout" at the unit-test level (a Soroban call either
+returns or panics within the same host invocation), so "transaction timeout
+handling" is covered by the request-TTL / expiration-ledger paths already
+present in `oracle` (`RequestTTL`, `ExpirationWarningLedgers`,
+`LastArchivalLedger`) — add a chaos test that advances the ledger past TTL
+mid-flight and confirms the request is rejected/archived rather than left
+in limbo.
+
+### Tier 2 — frontend fault injection
+
+Target `frontend/services/certificateVerificationService.ts`,
+`verificationStatusService.ts`, and `wallet.ts` / `walletAdapters.ts` — the
+layer that talks to Soroban RPC and Freighter.
+
+New `frontend/test/chaos/` harness, plain Jest (no new dependency):
+
+```ts
+// frontend/test/chaos/network.ts
+export function simulateNetworkFailure() // fetch rejects
+export function simulateTimeout(ms: number) // fetch never resolves; pair with AbortController assertions
+export function simulateFlaky(failCount: number) // fails N times, then succeeds — for retry/recovery tests
+export function simulateMalformedResponse(body: unknown) // 200 OK, invalid JSON shape
+```
+
+Test matrix per acceptance criterion:
+
+| Criterion | Test |
+|---|---|
+| Network failure simulation | `fetch` rejects → service surfaces a typed error, doesn't throw unhandled |
+| Transaction timeout handling | `AbortController` fires past a deadline → in-flight request is cancelled, UI leaves "pending" state rather than hanging forever |
+| Partial system failures | Wallet connects but Soroban RPC is unreachable (and vice versa) → each failure is attributable, not a generic "something went wrong" |
+| Recovery testing | `simulateFlaky(2)` → a retry wrapper succeeds on the 3rd attempt; assert exactly the expected number of calls |
+| Graceful degradation | RPC down → previously-cached verification result (if any) is still shown, clearly marked stale, instead of blanking the UI |
+| Error boundary testing | **Doesn't exist yet** — no `ErrorBoundary`/`componentDidCatch` anywhere in `frontend/`. Add a `VerificationErrorBoundary` around the async verification widgets ([features/verification](../../frontend/features/verification)) and test that a thrown render error shows a fallback instead of a blank page |
+
+## Non-goals for a first pass
+
+Full infra chaos (killing the Next.js process, simulating disk failure,
+Toxiproxy-style network partitioning) is out of scope — there's no
+persistent backend process to target. If a real backend/queue is added
+later, revisit with a proper fault-injection proxy.
+
+## Rollout
+
+1. Add the `frontend/test/chaos/` fault-injection helpers.
+2. Add the `VerificationErrorBoundary` component + test (currently missing).
+3. Retry/recovery + graceful-degradation tests on the verification services.
+4. Contract-side `panicking_registry` / `malformed_registry` mocks in
+   `oracle/src/test.rs`, plus the TTL-expiry-mid-flight test.
+5. Batch partial-failure test.

--- a/docs/testing/247-contract-snapshot-testing.md
+++ b/docs/testing/247-contract-snapshot-testing.md
@@ -1,0 +1,83 @@
+# #247 — Snapshot Testing for Contracts
+
+**Labels:** testing, contracts · **Priority:** Medium
+
+## Goal
+
+Catch unintended changes to contract behavior — state, events, storage
+layout, and gas cost — by comparing test output against a checked-in
+baseline, the same way UI snapshot testing catches unintended render diffs.
+
+## Blocker — fix before starting
+
+All three contract crates currently fail to build on `main` (confirmed via
+`gh run view` — every `Build & Test Soroban Contracts` CI job is red at the
+`cargo fmt --check` step):
+
+- `contracts/registry/src/lib.rs:1-8` and `contracts/oracle/src/lib.rs:1-18`
+  each have **two overlapping `use soroban_sdk::{...}` blocks** left over
+  from a merge that combined two feature branches without deduplicating —
+  the braces don't balance, so the file doesn't parse.
+- `contracts/registry` `DataKey` and `contracts/oracle` `DataKey` each
+  declare the **same variant name twice** (registry: `Provider`,
+  `ProviderList`, `TeeHash`; oracle: `Paused`, `ProviderStake`,
+  `ProviderWithdrawalCooldown`, `ArchivedRequest`, `LastArchivalLedger`,
+  `RequestTTL`, `ExpirationWarningLedgers`) — a hard `E0428` once the parse
+  error above is fixed.
+- `contracts/provenance/src/lib.rs:13-26` has the same kind of unbalanced
+  brace inside `ProvenanceError`.
+
+None of this is related to snapshot testing — it's merge damage. It has to
+be fixed (dedupe the variants, merge the import lists into one `use` block
+per file) before `cargo test` can run at all, which this issue depends on.
+
+## Current state
+
+Soroban SDK's `Env::default()` test harness already **auto-writes** a ledger
+replay file per test to `test_snapshots/**/<test_name>.1.json` (visible today
+in all three crates). That's a debugging/replay aid, regenerated on every
+run — nothing diffs it against a baseline or fails a test on drift. This
+issue is about adding actual **assertion-based** snapshots on top of that.
+
+## Proposed approach
+
+Add [`insta`](https://insta.rs) as a dev-dependency in each contract's
+`Cargo.toml`. It's the standard Rust snapshot-testing crate: `cargo insta
+test` runs tests and reports diffs against committed `.snap` files; `cargo
+insta review` is an interactive accept/reject workflow — which directly
+satisfies the "detect breaking changes" acceptance criterion (a
+behavior-changing PR fails CI until a human explicitly accepts the new
+snapshot).
+
+New file per crate: `contracts/<name>/src/snapshot_test.rs` (`#[cfg(test)]`,
+`mod snapshot_test;` added to `lib.rs`), covering the four criteria:
+
+| Criterion | Approach |
+|---|---|
+| **State snapshot comparison** | After a representative op (e.g. `submit_request`, `add_provider`, `mint`), read back the relevant storage entries and `assert_yaml_snapshot!` a normalized struct (addresses substituted with stable placeholders via `Address::generate` in a fixed-seed harness, so snapshots don't churn on every run). |
+| **Event emission snapshots** | Call the op, read `env.events().all()`, map to `(topics, data)` tuples, snapshot. Catches accidental topic renames, dropped events, or reordered payload fields. |
+| **Storage layout snapshots** | Snapshot the `DataKey` variant list itself (name + shape) via `stringify!`/`Debug` over an exhaustive `match`. The `match` being exhaustive means the compiler forces this test to be touched whenever a variant is added/removed/renamed — the snapshot then captures whether that change was intentional. |
+| **Gas usage snapshots** | After the op, read `env.budget().cpu_instruction_cost()` / `.memory_bytes_cost()` (soroban-sdk `testutils`) and assert against a stored baseline with a tolerance band (e.g. fail if cost regresses >10%). Exact-match would be too brittle across SDK patch bumps; a tolerance band is what actually catches a real regression (e.g. an accidental O(n) loop over `ProviderList`). |
+
+## CI wiring
+
+Add a step to each `Build & Test Soroban Contracts (<crate>)` job in
+`.github/workflows/ci.yml`, after the existing `cargo test` step:
+
+```yaml
+- name: Check contract snapshots
+  run: cargo insta test --check
+```
+
+Document `cargo insta review` (or the non-interactive `cargo insta accept`)
+in `contracts/IMPLEMENTATION.md` for contributors who need to accept an
+intentional change.
+
+## Rollout
+
+1. Fix the three merge-corrupted files (prerequisite, blocks everything below).
+2. Add `insta`, scaffold `snapshot_test.rs` for `registry` (smallest surface
+   with the multisig/proposal flow already well-covered by existing tests).
+3. Repeat for `provenance` (mint / lock / revoke / version-history state).
+4. Repeat for `oracle` (request lifecycle, dispute, staking, SLA).
+5. Wire the CI gate once all three have a non-empty snapshot baseline.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,16 @@
+# Testing Strategy — Design Docs
+
+Implementation designs for the four open testing issues, written against the
+actual current state of the codebase (not generic advice).
+
+| Issue | Doc | Priority |
+|---|---|---|
+| [#247 Snapshot Testing for Contracts](247-contract-snapshot-testing.md) | State/event/storage/gas snapshots for `oracle`, `registry`, `provenance` | Medium |
+| [#246 Chaos Engineering Tests](246-chaos-engineering-tests.md) | Cross-contract fault injection + frontend network/wallet chaos | Low |
+| [#245 API Contract Testing](245-api-contract-testing.md) | OpenAPI spec, contract tests, versioning, mock server, consumer-driven contracts | Medium |
+| [#244 Visual Regression Testing](244-visual-regression-testing.md) | Consolidate + extend the existing Playwright screenshot setup | Medium |
+
+**Read #247 first if you're picking up contract work** — it documents a
+pre-existing build break on `main` (merge corruption in all three contract
+`lib.rs` files) that blocks `cargo test`/`cargo build` for every contract,
+unrelated to snapshot testing itself but a hard prerequisite for it.


### PR DESCRIPTION
Adds implementation design docs for the four open testing issues, grounded in the current codebase rather than generic advice:

- closes #247 Snapshot Testing for Contracts
- closes #246 Chaos Engineering Tests
- closes #245 API Contract Testing
- closes #244 Visual Regression Testing

Note: #247's doc documents a pre-existing build break on main (merge corruption in all three contracts' lib.rs — mismatched import braces + duplicate DataKey enum variants) that currently fails CI and blocks any contract test work. Not fixed in this PR — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)